### PR TITLE
feat: Staging Layer (Silver) の構築と生データの命名規則統一 (#29)

### DIFF
--- a/enterprise_data_pipeline/models/staging/src_row_data.yml
+++ b/enterprise_data_pipeline/models/staging/src_row_data.yml
@@ -1,0 +1,14 @@
+version: 2
+
+sources:
+  - name: raw_data
+    description: "Snowflake上の生データ（Bronze層）"
+    database: OPTIMIZER_DB
+    schema: PUBLIC
+    tables:
+      - name: ORDERS
+        description: "注文履歴データ"
+      - name: PRODUCTS
+        description: "商品マスター"
+      - name: LOGISTICS_CENTERS
+        description: "物流拠点マスター"

--- a/enterprise_data_pipeline/models/staging/stg_logistics_centers.sql
+++ b/enterprise_data_pipeline/models/staging/stg_logistics_centers.sql
@@ -1,0 +1,14 @@
+with source as (
+    select * from {{ source('raw_data', 'LOGISTICS_CENTERS') }}
+),
+
+renamed as (
+    select
+        "CENTER_ID" as center_id,
+        "CENTER_NAME" as center_name,
+        "LATITUDE" as latitude,
+        "LONGITUDE" as longitude
+    from source
+)
+
+select * from renamed

--- a/enterprise_data_pipeline/models/staging/stg_orders.sql
+++ b/enterprise_data_pipeline/models/staging/stg_orders.sql
@@ -1,0 +1,16 @@
+with source as (
+    select * from {{ source('raw_data', 'ORDERS') }}
+),
+
+renamed as (
+    select
+        "ORDER_ID" as order_id,
+        "PRODUCT_ID" as product_id,
+        "CUSTOMER_LAT" as customer_lat,
+        "CUSTOMER_LON" as customer_lon,
+        -- 文字列をタイムスタンプ型へキャスト
+        cast("ORDER_DATE" as timestamp) as ordered_at
+    from source
+)
+
+select * from renamed

--- a/enterprise_data_pipeline/models/staging/stg_products.sql
+++ b/enterprise_data_pipeline/models/staging/stg_products.sql
@@ -1,0 +1,13 @@
+with source as (
+    select * from {{ source('raw_data', 'PRODUCTS') }}
+),
+
+renamed as (
+    select
+        "PRODUCT_ID" as product_id,
+        "PRODUCT_NAME" as product_name,
+        "WEIGHT_KG" as weight_kg
+    from source
+)
+
+select * from renamed


### PR DESCRIPTION
## 概要
Snowflake 上の生データ（Bronze）を dbt 管理下に置き、クレンジング済みデータ（Silver）として Staging Layer を構築しました。

## 実施内容
- **Source定義**: `src_raw_data.yml` にて `ORDERS`, `PRODUCTS`, `LOGISTICS_CENTERS` をソースとして登録。
- **Stagingモデルの実装**:
    - `stg_orders`: `ORDER_DATE` の TIMESTAMP 型キャストと、カラム名の小文字スネークケース化。
    - `stg_products`: 商品マスターのクレンジング。
    - `stg_logistics_centers`: 拠点マスターのクレンジング。
- **動作確認**: `dbt run --select staging` を実行し、Snowflake 上に 3 つのビューが正常に作成されることを確認済み。

## 完了定義の確認
- [x] Snowflake 上に `STG_` プレフィックスのビューが作成されていること。
- [x] 全てのモデルでカラム名が引用符なしで小文字として扱えること。

Closes #29