### PR TITLE
fix(Streamlit): Streamlit app の表示API非推奨対応

### DIFF
--- a/src/streamlit/app.py
+++ b/src/streamlit/app.py
@@ -124,11 +124,11 @@ warehouse_summary = (
 )
 
 with tab1:
-    st.bar_chart(warehouse_summary["SIMULATED_COST"], use_container_width=True)
+    st.bar_chart(warehouse_summary["SIMULATED_COST"], width="stretch")
 with tab2:
     st.dataframe(
         warehouse_summary.style.format({"SIMULATED_COST": "¥{:,.0f}"}),
-        use_container_width=True,
+        width="stretch",
     )
 
 # --- 4. 地理情報の可視化 (pydeck) ---


### PR DESCRIPTION
## 概要
Streamlitの `use_container_width` 引数が非推奨（2025-12-31削除予定）となったため、推奨される新仕様の `width` 指定へ移行しました。

## 修正内容
- `use_container_width=True` を使用している箇所を、同様の挙動を維持する `width="stretch"` に置換
- 対象ファイル: `src/streamlit/app.py`

## 動作確認結果
- [x] `uv run streamlit run src/streamlit/app.py` で起動し、コンソールに `use_container_width` に関する警告が表示されないことを確認。
- [x] 各コンポーネントが従来通り画面横幅いっぱいに表示されることを確認。

## 関連Issue
- Fixes #73 

Closes #73 