### PR TITLE
chore(config): exampleファイルを追加して初期設定テンプレートを整備

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,42 @@
+# ------------------------------------------------------------
+# App runtime variables (copy this file to .env and fill values)
+# ------------------------------------------------------------
+
+# Required: Snowflake account identifier
+SNOWFLAKE_ACCOUNT=your-account
+
+# Required for dbt wrapper (src/scripts/deploy/run_dbt.py)
+DEV_DBT_USER_RSA_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+
+# Required for Bronze loader (src/infrastructure/snowflake_loader.py)
+# You can use either SNOWFLAKE_LOADER_PRIVATE_KEY or DEV_LOADER_USER_RSA_PRIVATE_KEY.
+SNOWFLAKE_LOADER_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+# DEV_LOADER_USER_RSA_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+# SNOWFLAKE_LOADER_PRIVATE_KEY_PASSPHRASE=your-passphrase
+
+# Required for Streamlit app (src/streamlit/app.py)
+DEV_STREAMLIT_USER_RSA_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+
+# Optional loader overrides (defaults are derived from SNOWFLAKE_ENV)
+# SNOWFLAKE_ENV=DEV
+# SNOWFLAKE_LOADER_USER=DEV_LOADER_USER
+# SNOWFLAKE_LOADER_ROLE=DEV_LOADER_ROLE
+# SNOWFLAKE_LOADER_WAREHOUSE=DEV_LOADER_WH
+# SNOWFLAKE_LOADER_DATABASE=DEV_BRONZE_DB
+# SNOWFLAKE_LOADER_SCHEMA=RAW_DATA
+# SNOWFLAKE_LOADER_STAGE=DEV_BRONZE_RAW_STAGE
+# SNOWFLAKE_LOADER_FILE_FORMAT=DEV_CSV_FORMAT
+
+# Optional legacy variables for utility scripts
+# SNOWFLAKE_USER=your-user
+# SNOWFLAKE_PASSWORD=your-password
+# SNOWFLAKE_ROLE=your-role
+# SNOWFLAKE_WAREHOUSE=your-warehouse
+# SNOWFLAKE_DATABASE=your-database
+# SNOWFLAKE_SCHEMA=your-schema
+
+# ------------------------------------------------------------
+# Terraform note:
+# Prefer HCP Terraform Workspace Variables for TF_VAR_* values.
+# Do not keep TF_VAR_* secrets in shared .env by default.
+# ------------------------------------------------------------

--- a/.streamlit/secrets.toml.example
+++ b/.streamlit/secrets.toml.example
@@ -1,0 +1,9 @@
+# .streamlit/secrets.toml
+[connections.snowpark]
+account = "your-org-your-account"
+user = "your-user"
+password = "your-password-or-token"
+role = "DEV_DBT_ROLE"
+warehouse = "DEV_DBT_WH"
+database = "DEV_GOLD_DB"
+schema = "MARKETING_MART"

--- a/terraform/backend.dev.hcl.example
+++ b/terraform/backend.dev.hcl.example
@@ -1,0 +1,3 @@
+workspaces {
+  name = "dev-real-time-logistics-strategy-engine-distilled-mip-1m-01ms"
+}

--- a/terraform/backend.hcl.example
+++ b/terraform/backend.hcl.example
@@ -1,0 +1,2 @@
+# HCP Terraform organization name
+organization = "<your-hcp-organization>"

--- a/terraform/backend.prod.hcl.example
+++ b/terraform/backend.prod.hcl.example
@@ -1,0 +1,3 @@
+workspaces {
+  name = "prod-real-time-logistics-strategy-engine-distilled-mip-1m-01ms"
+}


### PR DESCRIPTION
## 概要
初期セットアップ時の迷いを減らすため、設定テンプレート（exampleファイル）を追加しました。  
実ファイルに秘密情報を置く運用は維持しつつ、必要なキー構造だけをリポジトリで共有できる状態にしています。

## 背景
- 新規参画時に「どの設定ファイルを作るべきか」が分かりづらい
- 秘密情報の誤コミットは避けたい
- Terraform とアプリ設定の雛形を揃えて、環境構築の再現性を上げたい

## 変更内容
- [.env.example](.env.example) を追加
- [.streamlit/secrets.toml.example](.streamlit/secrets.toml.example) を追加
- [terraform/backend.hcl.example](terraform/backend.hcl.example) を追加
- [terraform/backend.dev.hcl.example](terraform/backend.dev.hcl.example) を追加
- [terraform/backend.prod.hcl.example](terraform/backend.prod.hcl.example) を追加

## 期待効果
- 必要な設定キーを事前に把握できる
- `example` からコピーして初期セットアップを開始できる
- 機密情報を含む実ファイルをGit管理しない運用を徹底しやすくなる

## 影響範囲
- 設定テンプレートファイルの追加のみ
- 実行ロジック・アプリ挙動への直接影響なし

## 確認項目
- [ ] 新規環境で example ファイルをベースに設定作成できる
- [ ] 秘密情報を含む実ファイルは引き続き未追跡である