### PR TITLE
ci: Issue #111 の対策としてコード品質チェックを統合

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.sql]
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,11 @@ jobs:
       # uv sync で pyproject.toml / uv.lock から環境を完全再現
       run: uv sync --frozen --all-groups
 
-    - name: Lint with flake8
-      # uv run を通すことで、仮想環境内のライブラリを使用
+    - name: Run code quality checks
+      # flake8 とコミット済みテキストファイルの CR 混入をまとめて確認する。
+      # .env は Git 管理外のため、このチェック対象には含めない。
       run: |
-        uv run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        uv run flake8 . --count --max-complexity=10 --max-line-length=127 --statistics
+        uv run python src/scripts/quality/check_code_quality.py
 
     - name: Test with pytest
       # src/connection_test.py が pytest の収集対象になりエラーを吐くのを防ぐため、

--- a/src/scripts/quality/check_code_quality.py
+++ b/src/scripts/quality/check_code_quality.py
@@ -1,0 +1,153 @@
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_DOTENV_FILES = (".env",)
+TEXT_FILE_SUFFIXES = (
+    ".py",
+    ".yml",
+    ".yaml",
+    ".sql",
+    ".md",
+    ".toml",
+    ".cfg",
+    ".ini",
+)
+TEXT_FILE_NAMES = {".env.example"}
+
+
+def _run(command: list[str]) -> int:
+    print("[check]", " ".join(command))
+    completed = subprocess.run(command, cwd=REPO_ROOT, check=False)
+    return completed.returncode
+
+
+def _iter_tracked_text_files() -> list[Path]:
+    completed = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError("git ls-files failed while collecting tracked files")
+
+    files: list[Path] = []
+    for raw_path in completed.stdout.split(b"\0"):
+        if not raw_path:
+            continue
+        relative = Path(raw_path.decode("utf-8"))
+        if relative.name in TEXT_FILE_NAMES or relative.suffix in TEXT_FILE_SUFFIXES:
+            path = REPO_ROOT / relative
+            if path.is_file():
+                files.append(path)
+    return sorted(files)
+
+
+def _check_cr_in_files(paths: list[Path], label: str) -> int:
+    offenders: list[str] = []
+    for path in paths:
+        if b"\r" in path.read_bytes():
+            offenders.append(str(path.relative_to(REPO_ROOT)))
+
+    if not offenders:
+        print(f"[check] OK: no CR found in {label}")
+        return 0
+
+    print(f"[check] ERROR: CR (\\r) found in {label}:", file=sys.stderr)
+    for path in offenders:
+        print(path, file=sys.stderr)
+    return 1
+
+
+def _check_repo_crlf() -> int:
+    return _check_cr_in_files(_iter_tracked_text_files(), "git-tracked text files")
+
+
+def _check_dotenv(dotenv_path: str) -> int:
+    path = Path(dotenv_path)
+    if not path.is_absolute():
+        path = REPO_ROOT / path
+
+    if not path.exists():
+        print(f"[check] ERROR: dotenv file not found: {path}", file=sys.stderr)
+        return 2
+
+    return _check_cr_in_files([path], f"dotenv file {path.relative_to(REPO_ROOT)}")
+
+
+def _check_default_dotenv_files() -> int:
+    paths = [REPO_ROOT / name for name in DEFAULT_DOTENV_FILES]
+    existing_paths = [path for path in paths if path.exists()]
+
+    if not existing_paths:
+        print("[check] SKIP: default dotenv files not found")
+        return 0
+
+    return _check_cr_in_files(existing_paths, "default dotenv files")
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run lint and CRLF checks for tracked files, plus optional dotenv validation.",
+    )
+    parser.add_argument(
+        "--dotenv",
+        help="Optional dotenv file to check locally, e.g. .env",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+
+    lint_exit = _run(
+        [
+            "uv",
+            "run",
+            "flake8",
+            ".",
+            "--count",
+            "--select=E9,F63,F7,F82",
+            "--show-source",
+            "--statistics",
+        ]
+    )
+    if lint_exit != 0:
+        return lint_exit
+
+    style_exit = _run(
+        [
+            "uv",
+            "run",
+            "flake8",
+            ".",
+            "--count",
+            "--max-complexity=10",
+            "--max-line-length=127",
+            "--statistics",
+        ]
+    )
+    if style_exit != 0:
+        return style_exit
+
+    repo_crlf_exit = _check_repo_crlf()
+    if repo_crlf_exit != 0:
+        return repo_crlf_exit
+
+    default_dotenv_exit = _check_default_dotenv_files()
+    if default_dotenv_exit != 0:
+        return default_dotenv_exit
+
+    if args.dotenv:
+        return _check_dotenv(args.dotenv)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 概要

Issue #111 の対策として、`.env` に `\r` が混入した際の切り分けをしやすくし、あわせて Git 管理下ファイルの CR 混入も検知できるようにしました。

今回の変更では、コード品質チェックを 1 つのスクリプトに統合し、以下をまとめて確認できるようにしています。

- flake8 による静的チェック
- Git 管理下テキストファイルの CR 混入チェック
- ローカル `.env` の CR 混入チェック
- `.editorconfig` による LF 統一設定

## 背景

Issue #111 では、Windows/WSL 混在環境などで `.env` を編集した際に `\r` が紛れ込み、Snowflake 接続先ホスト名が壊れて接続エラーになる事象が問題になっていました。

ただし `.env` は通常 Git 管理外のため、CI から直接検査することはできません。
そのため、再発防止には以下の多層対策が必要です。

- ローカル実行時に `.env` を検査できること
- CI で Git 管理下ファイルの CR 混入を fail-fast できること
- エディタ設定で LF を基本に揃えること

## 変更内容

- `src/scripts/quality/check_code_quality.py` を追加
- flake8 の致命系チェックと通常チェックを 1 コマンドに統合
- Git 管理下のテキストファイルに対する CR 混入チェックを追加
- デフォルトで `.env` を確認し、存在しない場合はスキップするように対応
- `--dotenv` オプションで追加の dotenv ファイルも確認できるように対応
- CI から新しい品質チェック用スクリプトを実行するよう変更
- `.editorconfig` を追加し、LF を共通設定として明示

## このPRで対処していること / していないこと

対処していること:
- Git 管理ファイルに CR が混入した場合の検知
- ローカル `.env` に CR が混入した場合の検知
- 開発環境で LF を揃えるための共通設定

このPRだけでは対処しないこと:
- CI 上で Git 管理外の `.env` 実体を直接検査すること
- 既存の全ランタイム処理における env 値 sanitize の網羅的な修正

## 確認内容

- `uv run python src/scripts/quality/check_code_quality.py`
- `uv run python src/scripts/quality/check_code_quality.py --dotenv .env.example`
- `uv run flake8 src/scripts/quality/check_code_quality.py --count --statistics`

## 補足

CI では `.env` 実体が存在しないため、`.env` チェックは存在しない場合にスキップされます。
一方、ローカルでは `.env` が存在すればデフォルトで検査対象になります。

## 関連

- Closes #111
- 親Issue: #79
- 関連Issue: #102