### PR TITLE
chore: .gitignore に Copilot 指示ファイルを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ venv/
 .venv/
 .vscode/
 
+# GitHub
+.github/copilot-instructions.md
+
 # Snowflake / Credentials (絶対に含めない)
 .env
 creds.json


### PR DESCRIPTION
## 概要
GitHub Copilot 向けの指示ファイル（`copilot-sinstructions.md` および `.github/copilot-instructions.md`）が Git の管理対象に含まれないよう、`.gitignore` を更新し、既存の追跡対象から除外しました。

## 変更内容
ここに[引用コードブロック1]を挿入

## 背景 / 理由
- **差分ノイズの抑制**: 開発者ごとにローカルで微調整が発生しやすいファイルであり、本質的なロジック変更と無関係な差分が PR に混入するのを防ぐため。
- **レビューコストの低減**: `git status` や PR のファイル一覧から不要な情報を排除し、レビューアが重要なコード変更に集中できるようにするため。

## 影響範囲
- ローカルに存在する `copilot-sinstructions.md` 等のファイル自体は削除されませんが、Git の追跡対象からは外れます。
- 既にリポジトリにコミットされていた場合は、インデックスから削除されます。

## 確認事項
- [ ] `git status` を実行した際、対象ファイルが「Untracked files」に表示されないこと。
- [ ] `git rm --cached` により、リモートリポジトリから対象ファイルが（ファイル実体を消さずに）削除設定されていること。
引用コードブロック1