### PR TITLE
fix: sanitize対象にSILVER/GOLD DBを追加しCR混入時のdbt実行失敗を防止

### DIFF
--- a/src/scripts/deploy/run_dbt.py
+++ b/src/scripts/deploy/run_dbt.py
@@ -24,10 +24,14 @@ def _sanitize_runtime_env(env: dict[str, str]) -> None:
         "DEV_DBT_ROLE",
         "DEV_DBT_WH",
         "DEV_BRONZE_DB",
+        "DEV_SILVER_DB",
+        "DEV_GOLD_DB",
         "PROD_DBT_USER",
         "PROD_DBT_ROLE",
         "PROD_DBT_WH",
         "PROD_BRONZE_DB",
+        "PROD_SILVER_DB",
+        "PROD_GOLD_DB",
     ):
         value = env.get(key)
         if value is not None:


### PR DESCRIPTION
## 概要

Issue #112 の対応として、`run_dbt.py` の `_sanitize_runtime_env()` に
`DEV_SILVER_DB` / `DEV_GOLD_DB` / `PROD_SILVER_DB` / `PROD_GOLD_DB` を追加しました。

これにより、`.env` に CRLF が混入した場合でも、SILVER/GOLD 系 DB 変数の末尾 `\r` を除去できるようになります。

```
# 追加前（抜粋）
for key in (
    "SNOWFLAKE_ACCOUNT",
    "DEV_DBT_USER",
    "DEV_DBT_ROLE",
    "DEV_DBT_WH",
    "DEV_BRONZE_DB",
    "PROD_DBT_USER",
    "PROD_DBT_ROLE",
    "PROD_DBT_WH",
    "PROD_BRONZE_DB",
):
```

## 背景

これまで `BRONZE_DB` 系は sanitize 対象でしたが、`SILVER_DB` / `GOLD_DB` は対象外でした。
そのため、Windows/WSL 混在環境で `.env` に `\r` が混入すると、dbt 実行時に DB 名が壊れ、
`SHOW VIEWS IN SCHEMA ...` などが `Object does not exist` で失敗しうる状態でした。

## 変更内容

- `src/scripts/deploy/run_dbt.py`
  - `_sanitize_runtime_env()` の対象キーを拡張
  - 追加キー:
    - `DEV_SILVER_DB`
    - `DEV_GOLD_DB`
    - `PROD_SILVER_DB`
    - `PROD_GOLD_DB`

```
# 追加後（抜粋）
for key in (
    "SNOWFLAKE_ACCOUNT",
    "DEV_DBT_USER",
    "DEV_DBT_ROLE",
    "DEV_DBT_WH",
    "DEV_BRONZE_DB",
    "DEV_SILVER_DB",
    "DEV_GOLD_DB",
    "PROD_DBT_USER",
    "PROD_DBT_ROLE",
    "PROD_DBT_WH",
    "PROD_BRONZE_DB",
    "PROD_SILVER_DB",
    "PROD_GOLD_DB",
):
```

## 期待効果

- `.env` の改行コード混入に対する耐性向上
- DEV/PROD 両環境で DB 変数 sanitize の網羅性を確保
- CR 混入由来の切り分け困難な接続/SQL失敗を低減

## 確認

- `uv run ruff check src/scripts/deploy/run_dbt.py` を実行し、lint エラーがないことを確認済み

## 関連

- Closes #112
- 関連: #111
- 関連: #102