### PR TITLE
feat(ci): prod Terraform plan の可視化基盤をCIに追加（PR/手動実行 + Artifact保存）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      run_prod_plan:
+        description: "Run prod terraform plan"
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   lint-and-test:
@@ -130,3 +137,50 @@ jobs:
         SNOWFLAKE_DBT_PRIVATE_KEY_PASSPHRASE: ${{ secrets.SNOWFLAKE_PRIVATE_KEY_PASSPHRASE }}
       run: |
         uv run python src/scripts/deploy/verify_dbt_view_rebuild.py
+
+  terraform-prod-plan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'workflow_dispatch' && inputs.run_prod_plan)
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v3
+
+    - name: Prepare env for terraform wrapper
+      env:
+        HCP_TF_ORGANIZATION: ${{ secrets.HCP_TF_ORGANIZATION }}
+      run: |
+        if [ -z "${HCP_TF_ORGANIZATION}" ]; then
+          echo "[terraform-prod-plan] HCP_TF_ORGANIZATION secret is required" >&2
+          exit 1
+        fi
+        cat > .env <<EOF
+HCP_TF_ORGANIZATION=${HCP_TF_ORGANIZATION}
+EOF
+
+    - name: Run prod terraform plan via wrapper
+      env:
+        APP_ENV: prod
+        CI: true
+        GITHUB_ACTIONS: true
+        TF_TOKEN_app_terraform_io: ${{ secrets.HCP_TERRAFORM_TOKEN }}
+      run: |
+        mkdir -p artifacts/terraform
+        ./terraform/tf plan -no-color | tee artifacts/terraform/prod-plan.log
+
+    - name: Save terraform plan artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: terraform-prod-plan-${{ github.run_id }}
+        path: |
+          artifacts/terraform/prod-plan.log
+          terraform/98_runtime.auto.tfvars
+          terraform/99_app_env.auto.tfvars
+        if-no-files-found: warn


### PR DESCRIPTION
## 概要
本PRは #105 のサブイシュー対応として、prod 変更の見える化と再現性を先に整備するため、CIに Terraform plan 基盤を追加します。
```
- pull_request / workflow_dispatch で実行可能な `terraform-prod-plan` ジョブを追加
- `terraform/tf plan -no-color` の実行ログを保存
- plan 実行時の関連ファイルを Artifact 化
```

## 変更内容
```
- `.github/workflows/ci.yml`
  - `workflow_dispatch` 入力 `run_prod_plan` を追加
  - `terraform-prod-plan` ジョブを追加
  - 実行条件:
    - pull_request
    - workflow_dispatch かつ `run_prod_plan=true`
  - 実行処理:
    - Terraform セットアップ
    - 最小 `.env` 生成（`HCP_TF_ORGANIZATION`）
    - `APP_ENV=prod` で `./terraform/tf plan -no-color` 実行
    - `artifacts/terraform/prod-plan.log` を生成
  - Artifact 保存:
    - `artifacts/terraform/prod-plan.log`
    - `terraform/98_runtime.auto.tfvars`
    - `terraform/99_app_env.auto.tfvars`
```

## 期待する効果
- prod 変更前の差分を PR 上で確認可能
- 手動実行でも同じ手順を再現可能
- 実行ログと関連ファイルを Artifact として監査可能

## 関連
- Parent: #105