### PR TITLE
fix(ci): prod apply後コメント処理の権限設定を修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
   terraform-prod-apply:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     environment: prod
     needs: [lint-and-test]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'


### PR DESCRIPTION
## 概要
prod apply 実行後に commit comment を投稿する step が 403 で失敗していたため、GitHub Actions の権限設定を修正しました。

## 背景
terraform-prod-apply ジョブ内の actions/github-script が commit comment 作成 API を呼び出す際、`contents: read` 権限では書き込みが許可されず、`Resource not accessible by integration (403)` が発生していました。

## 変更内容
```
変更ファイル: .github/workflows/ci.yml

terraform-prod-apply:
  permissions:
    contents: write  # read -> write に変更
```

## 期待される動作
- prod apply 実行後、結果サマリの commit comment 投稿が成功する
- apply 本体と artifact 保存の挙動は従来どおり維持される

## 影響範囲
- CI 設定のみ（アプリ本体コード変更なし）
- 対象は terraform-prod-apply ジョブの権限設定に限定

## 検証観点
- main push 後の terraform-prod-apply 実行で 403 が再発しないこと
- Comment on commit with apply result step が成功すること
- prod-apply.log artifact が保存されること

## 関連
- Follow-up for #139