### PR TITLE
docs(ops): prod運用手順を最終更新し復旧Runbookを追加

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -353,7 +353,9 @@ CI/CD ワークフローで使用する秘密情報は、GitHub Repository Secre
 
 ## 2. 実行手順
 
-Docker コンテナ内で実行する場合も、初回は `terraform login` による認可が必要です。
+`terraform/tf` は `.env.shared` / `.env` または CI Secrets から
+`TF_TOKEN_app_terraform_io`（互換: `HCP_TERRAFORM_TOKEN`, `HCP_TF_TEAM_API_TOKEN`）を読み込みます。
+`terraform login` は不要です。
 
 ### 2.1. DEV / PROD 共通手順
 
@@ -381,6 +383,33 @@ Docker コンテナ内で実行する場合も、初回は `terraform login` に
 
 - CI では `APP_ENV=prod ./terraform/tf plan` / `apply` の形式を利用できます。
 - ラッパーを使わずに `terraform` コマンドを直接実行する運用は推奨しません。
+
+## 2.2. 復旧手順（運用者向け Runbook）
+
+prod apply が失敗した場合、次の順で切り分けて復旧してください。
+
+1. **Actions 実行履歴の確認**
+    - 対象 run: `CI Pipeline` の `terraform-prod-apply`
+    - `prod-apply.log` artifact をダウンロードしてエラー行を特定
+2. **Environment 保護の確認**
+    - `Settings > Environments > prod`
+    - Deployment branches が `main` 限定か確認
+    - Required reviewers が有効か確認
+3. **Secrets の有効性確認**
+    - `HCP_TERRAFORM_TOKEN` が CI 用 Team API Token であること
+    - `HCP_TF_ORGANIZATION` が正しいこと
+    - トークン失効時は再発行して Secrets を更新
+4. **HCP Terraform 権限確認**
+    - CI 用 Team が prod workspace で apply 可能であること
+    - 開発者ロールに prod apply 権限が付与されていないこと
+5. **再実行**
+    - 必要に応じて main へ修正コミットをマージし、再度 approval 後に apply
+
+**緊急時（break-glass）ポリシー:**
+
+- 原則としてローカルから prod 変更は行わない
+- 例外対応は Issue を起票し、実施者・理由・実行コマンド・結果を記録する
+- 事後に CI 経路へ設定を戻し、Secrets と権限の棚卸しを実施する
 
 ## 3. 設計判断（ADR）
 


### PR DESCRIPTION
## 概要

Issue #105 の完了条件として、prod 運用ドキュメント（terraform/README.md）を最終整備します。

- `terraform login` 前提の古い記述を削除し、Team API Token 読み込み方式に統一
- 運用者向け復旧手順（Runbook）を新設
- Environment 保護設定・Secrets 管理・トラブルシューティング手順を確認可能にする

Closes #105

---

## 変更内容

### `terraform/README.md`

**セクション 2.0: 実行手順（全体アナウンス更新）**
- 削除: `terraform login` による認可が必要という古い前提
- 追加: Team API Token を自動読み込みする `terraform/tf` ラッパーの説明

**セクション 2.2: 復旧手順（新設 — 運用者向け Runbook）**
- Actions 実行履歴確認
- Environment 保護設定確認
- Secrets 有効性確認
- HCP Terraform 権限確認
- 再実行手順
- Break-glass ポリシー（例外対応）

---

## 関連ドキュメント

- Environment 保護設定: セクション 1.1–1.7
- Secrets 一覧と設定手順: セクション 1.8
- CI ワークフロー詳細: セクション 1.5
- 設計判断（ADR）: セクション 3

---

## テスト

ドキュメント更新のため自動テスト不要。
マージ前に内容妥当性を確認してください。

---

## マージ後の確認

Issue #105 完了時に以下を実施してください:
- [ ] #105 に完了証跡（ローカル拒否ログ / Actions run URL / artifact 保管方針）を貼る
- [ ] Issue #105 を Close