### PR TITLE
build: Docker開発用と本番用イメージを分離

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,46 @@
+# Deployment Guide
+
+## Multi-stage Docker Build
+
+This repository uses a single `Dockerfile` with two runtime targets:
+
+- `development`: includes developer tooling (`gh`, `git`, `terraform`, `tflint`)
+- `production`: minimal runtime image for deployment
+
+## Local Development Build
+
+`docker-compose.yml` is configured to build with `target: development`.
+
+```bash
+docker compose build
+```
+
+After build, verify developer tools are available:
+
+```bash
+docker compose run --rm streamlit gh --version
+docker compose run --rm streamlit git --version
+docker compose run --rm streamlit tflint --version
+```
+
+## Production Build
+
+Build a minimal production image:
+
+```bash
+docker build --target production -t real-time-logistics-strategy-engine:prod .
+```
+
+Run verification checks to ensure dev tools are not bundled:
+
+```bash
+docker run --rm real-time-logistics-strategy-engine:prod sh -lc 'command -v gh || echo "gh: not installed"'
+docker run --rm real-time-logistics-strategy-engine:prod sh -lc 'command -v git || echo "git: not installed"'
+```
+
+## CI Recommendation
+
+In CI, explicitly choose build target by job purpose:
+
+- lint/test jobs that need tooling: `--target development`
+- deployment image build/push: `--target production`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,74 +1,72 @@
-# --- Build Stage ---
-FROM python:3.11 AS builder
+FROM python:3.11-slim AS base
 
-# uvのインストール (再頒布性と速度のため、公式バイナリを使用)
+# uv binaries for deterministic and fast dependency management.
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
-# 作業ディレクトリの設定
-WORKDIR /app
-
-# 依存関係ファイルのコピー
-# キャッシュを効かせるため、ソースコードより先にコピーする
-COPY pyproject.toml uv.lock ./
-
-# 依存関係のインストール
-# --mount=type=cache を使用してビルド速度を向上
-# --frozen を使用して uv.lock と完全に一致させる
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-install-project --no-dev
-
-# プロジェクト本体をインストールして、実行時のimport不整合を防ぐ
-COPY . .
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev
-
-# --- Runtime Stage ---
-FROM python:3.11
-
-# runtimeでも uv/uvx を利用できるようにする
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
-
-# 開発コンテナ内で Git 操作できるように最低限のツールを入れる
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    git \
-    gnupg \
-    lsb-release \
-    openssh-client \
-    wget \
-    && wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor > /usr/share/keyrings/hashicorp-archive-keyring.gpg \
-    && chmod 644 /usr/share/keyrings/hashicorp-archive-keyring.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" > /etc/apt/sources.list.d/hashicorp.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends terraform \
-    && rm -rf /var/lib/apt/lists/*
-
-# 日本語ロケールやタイムゾーンが必要な場合はここで設定
 ENV TZ=Asia/Tokyo \
     LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
-    # Pythonが.pycファイルを作成しないようにする
     PYTHONDONTWRITEBYTECODE=1 \
-    # ログがバッファリングされないようにする
     PYTHONUNBUFFERED=1 \
-    # uvの仮想環境をPATHに追加
     PATH="/app/.venv/bin:$PATH"
 
 WORKDIR /app
 
-# ビルドステージから仮想環境をコピー
-COPY --from=builder /app/.venv /app/.venv
+# Keep runtime base minimal. Development-only tools are installed in the development stage.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    openssh-client \
+    wget \
+    gnupg \
+    lsb-release \
+    && rm -rf /var/lib/apt/lists/*
 
-# ソースコードのコピー
+
+FROM base AS deps-dev
+COPY pyproject.toml uv.lock ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-install-project
+
+
+FROM base AS deps-prod
+COPY pyproject.toml uv.lock ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-install-project --no-dev
+
+
+FROM base AS development
+
+# Development toolchain: gh, git, terraform, tflint.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    unzip \
+    && wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor > /usr/share/keyrings/hashicorp-archive-keyring.gpg \
+    && chmod 644 /usr/share/keyrings/hashicorp-archive-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" > /etc/apt/sources.list.d/hashicorp.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends terraform gh \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN TFLINT_VERSION=v0.54.0 \
+    && curl -sSL -o /tmp/tflint.zip "https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VERSION}/tflint_linux_amd64.zip" \
+    && unzip -q /tmp/tflint.zip -d /usr/local/bin \
+    && chmod +x /usr/local/bin/tflint \
+    && rm -f /tmp/tflint.zip
+
+COPY --from=deps-dev /app/.venv /app/.venv
 COPY . .
 
-# 各サービスのデフォルトポートを公開
-# Streamlit: 8501
-# FastAPI: 8000
-# Dagster: 3000
 EXPOSE 8501 8000 3000
+CMD ["sh"]
 
-# 実行コマンドは docker-compose.yml 側で
-# サービス（Streamlit/FastAPI等）ごとに上書きすることを想定
+
+FROM base AS production
+
+COPY --from=deps-prod /app/.venv /app/.venv
+COPY . .
+
+EXPOSE 8501 8000 3000
 CMD ["sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      target: development
     image: real-time-logistics-strategy-engine:latest
     container_name: real-time-logistics-strategy-engine-streamlit
     ports:
@@ -24,6 +25,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      target: development
     image: real-time-logistics-strategy-engine:latest
     container_name: real-time-logistics-strategy-engine-api
     ports:
@@ -43,6 +45,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      target: development
     image: real-time-logistics-strategy-engine:latest
     container_name: real-time-logistics-strategy-engine-dagster
     ports:


### PR DESCRIPTION
## 概要

Docker イメージの構成を見直し、開発用と本番用の責務を分離しました。
ローカル開発では必要なツールを利用できる状態を維持しつつ、本番向けには不要な開発ツールを含まない最小構成のイメージをビルドできるようにしています。

## 変更内容

- Dockerfile をマルチステージ構成に変更
- 開発用の development ターゲットを追加
- 本番用の production ターゲットを追加
- docker-compose で development ターゲットを利用するよう変更
- デプロイおよび確認手順を DEPLOYMENT.md に追加

## 背景

これまでは開発時に必要なツールと実行環境が同一イメージに含まれていました。
そのため、開発用途には便利な一方で、本番利用には不要なツールまで含まれる構成になっていました。

今回の変更で、用途ごとにビルドターゲットを分けることで、開発体験を維持しながら本番イメージをより明確かつ軽量に扱えるようにしています。

## 期待する効果

- 開発用コンテナで gh、git、terraform、tflint などのツールを利用できる
- 本番用イメージに不要な開発ツールを含めずに済む
- CI やデプロイ時に用途に応じてビルドターゲットを選択しやすくなる

## 影響範囲

- Docker ベースのローカル開発環境
- docker-compose を利用した起動方法
- 本番イメージのビルド手順

## 確認事項

- docker-compose による各サービスの build が development ターゲットで成功すること
- development ターゲットで開発用ツールが利用できること
- production ターゲットで不要なツールが含まれていないこと
