### PR TITLE
docs: DECISIONS/ADR を導入して設計判断を明文化

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,6 +168,24 @@ tflint --chdir=terraform
 - 観測結果（検知・復旧・影響範囲）
 - フォローアップ（恒久対策の要否）
 
+## 5.4 設計判断 (ADR) の更新ルール
+
+重要設計の変更を伴う場合、同一 PR で ADR を追加または更新してください。
+
+ADR 対象の例:
+
+- Terraform / Snowflake の権限モデル変更
+- 本番実行経路・承認フロー変更
+- 破壊的変更ポリシー（`prevent_destroy` など）の変更
+- 環境切替や命名規則など、長期運用へ影響する規約変更
+
+運用手順:
+
+1. `docs/DECISIONS.md` の ADR 一覧を更新する
+2. `docs/adr/ADR-XXXX-*.md` を追加または更新する
+3. 既存判断を変更する場合は新規 ADR を作成し、旧 ADR を `Superseded` とする
+4. PR 本文の影響範囲に、対象 ADR を明記する
+
 ## 6. CI/CD との整合
 
 - CI は lint と test を並列実行します。

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,0 +1,44 @@
+# DECISIONS
+
+このドキュメントは、本プロジェクトの重要な設計判断を ADR (Architecture Decision Record) として管理するための入口です。
+
+## 1. 目的
+
+- なぜその設計にしたのかを、実装と紐づけて追跡できるようにする
+- 将来の変更時に、判断の前提とトレードオフを再利用できるようにする
+- レビュー時に、実装差分だけでなく設計意図の確認を可能にする
+
+## 2. ADR フォーマット
+
+各 ADR は `docs/adr/` 配下に 1 ファイルずつ作成し、以下の形式を採用します。
+
+### 2.1 必須ヘッダ
+
+- `# ADR-XXXX: タイトル`
+- `- Status: Proposed | Accepted | Superseded`
+- `- Date: YYYY-MM-DD`
+- `- Deciders: @team or role`
+
+### 2.2 必須セクション
+
+- `## Context`
+- `## Decision`
+- `## Consequences`
+- `## Implementation References`
+
+`Implementation References` には、該当実装ファイルのパスを必ず記載します。
+
+## 3. 運用ルール
+
+- 重要設計の変更を伴う PR では、同一 PR で ADR を追加または更新する
+- 既存判断を変更する場合は、既存 ADR を上書きせず、新しい ADR を追加して `Superseded` を明記する
+- 破壊的変更、権限モデル変更、実行経路変更 (ローカル可否や本番ガード) は ADR 対象とする
+
+## 4. ADR 一覧
+
+| ID | Title | Status | Date | File |
+| --- | --- | --- | --- | --- |
+| ADR-0001 | HCP Terraform Remote Backend を標準化する | Accepted | 2026-03-30 | `docs/adr/ADR-0001-hcp-terraform-remote-backend.md` |
+| ADR-0002 | 本番 Terraform apply は CI 承認ゲート経由に限定する | Accepted | 2026-03-30 | `docs/adr/ADR-0002-prod-apply-via-ci-approval-gate.md` |
+| ADR-0003 | Snowflake リソースの prevent_destroy を現段階で false とする | Accepted | 2026-03-30 | `docs/adr/ADR-0003-prevent-destroy-false-bootstrap-phase.md` |
+| ADR-0004 | 環境差分は app_env と入力変数で吸収し命名を統制する | Accepted | 2026-03-30 | `docs/adr/ADR-0004-env-switch-and-naming-governance.md` |

--- a/docs/adr/ADR-0001-hcp-terraform-remote-backend.md
+++ b/docs/adr/ADR-0001-hcp-terraform-remote-backend.md
@@ -1,0 +1,34 @@
+# ADR-0001: HCP Terraform Remote Backend を標準化する
+
+- Status: Accepted
+- Date: 2026-03-30
+- Deciders: data-platform team
+
+## Context
+
+Snowflake 基盤リソースを複数メンバーで安全に運用するには、Terraform の状態管理をローカルに分散させず、一貫した実行基盤を持つ必要がある。
+また、環境ごとにワークスペースを分離し、実行主体の認可情報を統制する必要がある。
+
+## Decision
+
+- Terraform の backend は HCP Terraform (Remote Backend) を標準とする
+- 実行は `terraform/tf` ラッパーを標準経路とし、Organization / Workspace / Token の解決をこのラッパーで統一する
+- `dev` / `prod` は HCP Terraform の別ワークスペースにマッピングする
+- 現在の課金レベルは Essentials とし、Project 単位の Team 権限制御で Terraform 実行権限をチーム境界で管理する（Essentials 以上）
+
+## Consequences
+
+- 実行者ごとのローカル state 差異を回避できる
+- backend 設定と認証注入の手順が一本化される（Free でも可）
+- Project 単位の Team 権限制御により、権限管理の統制がしやすくなる（Essentials 以上）
+- Workspace の Runs 画面で、実行履歴（実行者、起点、時刻、イベントタイムライン、plan/apply 出力）を確認できる（Free でも可）
+- 本リポジトリは `terraform/tf` ラッパー経由で HCP Terraform Remote Backend を利用し、CI 実行分を含む run 履歴を HCP Terraform 側で追跡する
+- Terraform 全般で設定不備は plan/apply の失敗要因となる。加えて本構成では HCP Terraform の可用性、Organization / Workspace / Token 設定に依存するため、これらの不備時は plan/apply が停止する
+- Essentials を解約して Free へ移行した場合、Project 単位の Team 権限制御は利用できなくなるため、権限設計の見直しが必要になる
+
+## Implementation References
+
+- `terraform/providers.tf`
+- `terraform/tf`
+- `terraform/README.md`
+- `README.md`

--- a/docs/adr/ADR-0002-prod-apply-via-ci-approval-gate.md
+++ b/docs/adr/ADR-0002-prod-apply-via-ci-approval-gate.md
@@ -1,0 +1,29 @@
+# ADR-0002: 本番 Terraform apply は CI 承認ゲート経由に限定する
+
+- Status: Accepted
+- Date: 2026-03-30
+- Deciders: data-platform team
+
+## Context
+
+本番環境への Terraform apply は影響範囲が大きく、個人端末からの直接実行では監査性と統制が不足する。
+既存運用では GitHub Actions と Environment 承認を組み合わせたフローを整備している。
+
+## Decision
+
+- `APP_ENV=prod` の Terraform 実行は CI 実行時のみ許可する
+- 本番 apply は GitHub Actions の `environment: prod` 承認ゲートを通過したジョブから実行する
+- 承認ポイントはパイプライン内で 1 回に集約し、承認後は apply -> loader -> dbt run -> dbt test を自動継続する
+
+## Consequences
+
+- 本番変更の経路が一意化され、監査証跡が残る
+- 手動オペレーションのばらつきが減る
+- 緊急時にも CI 経路が前提となるため、GitHub 側設定と権限設計の維持が必要になる
+
+## Implementation References
+
+- `.github/workflows/ci.yml`
+- `terraform/tf`
+- `DEPLOYMENT.md`
+- `terraform/README.md`

--- a/docs/adr/ADR-0003-prevent-destroy-false-bootstrap-phase.md
+++ b/docs/adr/ADR-0003-prevent-destroy-false-bootstrap-phase.md
@@ -1,0 +1,28 @@
+# ADR-0003: Snowflake リソースの prevent_destroy を現段階で false とする
+
+- Status: Accepted
+- Date: 2026-03-30
+- Deciders: data-platform team
+
+## Context
+
+本プロジェクトは構築・検証フェーズであり、Snowflake リソースの再作成を伴う試行錯誤が継続している。
+`prevent_destroy = true` を広範囲に適用すると、検証時の再構築速度が低下し、運用負荷が増える。
+
+## Decision
+
+- `terraform/modules/snowflake_env/main.tf` の主要リソースでは、現時点で `lifecycle.prevent_destroy = false` を採用する
+- 破壊的変更を行う PR では、影響範囲・復旧手順・再有効化条件を必ず記載する
+- 本番安定化フェーズで、重要リソースから段階的に `true` へ移行する方針を維持する
+
+## Consequences
+
+- 開発・検証時の反復速度を確保できる
+- 誤削除リスクは残るため、レビューと承認ゲートで補完する必要がある
+- 将来の運用フェーズ移行時に、保護設定の再評価タスクが必要になる
+
+## Implementation References
+
+- `terraform/modules/snowflake_env/main.tf`
+- `terraform/README.md`
+- `CONTRIBUTING.md`

--- a/docs/adr/ADR-0004-env-switch-and-naming-governance.md
+++ b/docs/adr/ADR-0004-env-switch-and-naming-governance.md
@@ -1,0 +1,29 @@
+# ADR-0004: 環境差分は app_env と入力変数で吸収し命名を統制する
+
+- Status: Accepted
+- Date: 2026-03-30
+- Deciders: data-platform team
+
+## Context
+
+dev/prod を別コードで管理すると、変更漏れとドリフトが発生しやすい。
+一方、同一コードで環境切り替えを行う場合は、命名値と接続先の注入規約を厳格にする必要がある。
+
+## Decision
+
+- ルートの `terraform/main.tf` では `app_env` を基準に各リソース名を切り替える
+- 命名値は `.env.shared` / `.env` に集約し、`terraform/tf` が `TF_VAR_*` と `*.auto.tfvars` を生成して注入する
+- 環境差分は変数で扱い、構成ファイルの重複分岐は作らない
+
+## Consequences
+
+- 単一コードベースで dev/prod の整合を取りやすい
+- 命名規則と環境変数セットの破損時に実行不能となるため、設定ファイルの管理品質が重要になる
+- レビュー時に「変数追加・改名」の影響が広がるため、変更時は ADR とドキュメントの同時更新が必要になる
+
+## Implementation References
+
+- `terraform/main.tf`
+- `terraform/variables.tf`
+- `terraform/tf`
+- `CONTRIBUTING.md`


### PR DESCRIPTION
## 概要
- docs/DECISIONS.md を新規作成し、ADR 管理ルールを定義
- docs/adr に初期 ADR 4 件を追加
- CONTRIBUTING.md に ADR 更新ルールを追記

## 変更ファイル
- CONTRIBUTING.md
- docs/DECISIONS.md
- docs/adr/ADR-0001-hcp-terraform-remote-backend.md
- docs/adr/ADR-0002-prod-apply-via-ci-approval-gate.md
- docs/adr/ADR-0003-prevent-destroy-false-bootstrap-phase.md
- docs/adr/ADR-0004-env-switch-and-naming-governance.md

## テスト
- /app/.venv/bin/python src/scripts/quality/check_code_quality.py --only markdown

Closes #153