### PR TITLE
ci: GitHub ActionsをNode.js24互換バージョンに更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Setup Terraform
         if: matrix.check == 'terraform'
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
 
       - name: Install shellcheck
         if: matrix.check == 'shell'
@@ -218,7 +218,7 @@ jobs:
     steps:
       - *checkout_step
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
 
       - name: Prepare env for terraform wrapper
         env:
@@ -242,7 +242,7 @@ jobs:
 
       - name: Save terraform plan artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: terraform-prod-plan-${{ github.run_id }}
           path: |
@@ -272,7 +272,7 @@ jobs:
     steps:
       - *checkout_step
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
 
       - name: Prepare env for terraform wrapper
         env:
@@ -296,7 +296,7 @@ jobs:
 
       - name: Save terraform apply artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: terraform-prod-apply-${{ github.run_id }}
           path: |
@@ -343,7 +343,7 @@ jobs:
 
       - name: Save loader artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: prod-loader-${{ github.run_id }}
           path: artifacts/data-pipeline/prod-loader.log
@@ -374,7 +374,7 @@ jobs:
 
       - name: Save dbt run artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: prod-dbt-run-${{ github.run_id }}
           path: |
@@ -407,7 +407,7 @@ jobs:
 
       - name: Save dbt test artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: prod-dbt-test-${{ github.run_id }}
           path: |


### PR DESCRIPTION
## 概要
- hashicorp/setup-terraform@v3 → v4 に更新
- actions/upload-artifact@v4 → v7 に更新

## 背景
GitHub Actions ランナーの Node.js 20 は以下のスケジュールで廃止予定:
- 2026-06-02: Node.js 24 がデフォルトに変更
- 2026-09-16: Node.js 20 を完全削除

## 影響範囲
- CI workflow (lint-terraform, terraform-prod-plan, terraform-prod-apply)
- Artifact アップロード機能 (全 dbt/terraform ジョブ)

## 検証
- yaml lint: ok ✓

## 関連リソース
- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/