### PR TITLE
ci: github-scriptをNode.js24対応のv8へ更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,7 +307,7 @@ jobs:
 
       - name: Comment on commit with apply result
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## 概要
- `terraform-prod-apply` で使用している `actions/github-script` を `v7` から `v8` に更新
- Node.js 20 廃止アナウンスに伴う deprecation annotation を解消
- GitHub Actions の Node.js 24 既定化に先回りして互換性を確保

## 背景
- `actions/github-script@v7` は Node.js 20 ランタイムで動作
- GitHub Actions ランナーでは 2026-06-02 から Node.js 24 が既定化され、2026-09-16 に Node.js 20 が削除予定
- `actions/github-script@v8` は Node.js 24 ランタイムに対応

## 影響範囲
- `.github/workflows/ci.yml` の `terraform-prod-apply` ジョブ内コメント投稿ステップのみ
- Terraform apply の実行順序、承認フロー、artifact 保存処理には変更なし

## 検証
- `python3 src/scripts/quality/check_code_quality.py --only yaml`

## 期待効果
- `terraform-prod-apply` の Node.js 20 deprecation annotation を解消
- GitHub Actions の将来ランタイム変更による予期しない失敗リスクを低減