### PR TITLE
fix(ci): remote backend非対応の-outオプションを削除しapplyを直接実行に変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,7 @@ jobs:
         run: |
           mkdir -p artifacts/terraform
           terraform -chdir=terraform init -reconfigure -backend-config=backend.prod.hcl
-          terraform -chdir=terraform plan -no-color -out=../artifacts/terraform/prod.tfplan | tee artifacts/terraform/prod-plan.log
+          terraform -chdir=terraform plan -no-color | tee artifacts/terraform/prod-plan.log
 
       - name: Save terraform plan artifacts
         if: always()
@@ -253,7 +253,6 @@ jobs:
           name: terraform-prod-plan-${{ github.run_id }}
           path: |
             artifacts/terraform/prod-plan.log
-            artifacts/terraform/prod.tfplan
           if-no-files-found: warn
 
   terraform-provider-upgrade-check:
@@ -307,6 +306,7 @@ jobs:
 
       - name: Download prod terraform plan artifact
         uses: actions/download-artifact@v5
+        if: false  # remote backend では plan ファイルの受け渡しは不要
         with:
           name: terraform-prod-plan-${{ github.run_id }}
           path: artifacts/terraform
@@ -318,7 +318,7 @@ jobs:
         run: |
           mkdir -p artifacts/terraform
           terraform -chdir=terraform init -reconfigure -backend-config=backend.prod.hcl
-          terraform -chdir=terraform apply -auto-approve ../artifacts/terraform/prod.tfplan | tee artifacts/terraform/prod-apply.log
+          terraform -chdir=terraform apply -auto-approve | tee artifacts/terraform/prod-apply.log
 
       - name: Save terraform apply artifacts
         if: always()


### PR DESCRIPTION
## 概要

HCP Terraform (remote backend) は `terraform plan -out=<file>` でプラン結果をローカルに保存できないため、CI が以下のエラーで落ちていた問題を修正。

```
Error: Saving a generated plan is currently not supported
The "remote" backend does not support saving the generated execution plan locally at this time.
```

## 変更内容

- `terraform-prod-plan`: `-out=../artifacts/terraform/prod.tfplan` を削除。ログのみ artifact として保存。
- `terraform-prod-apply`: prod.tfplan ダウンロードステップを無効化（`if: false`）。`apply -auto-approve` を直接実行（HCP が最新の plan を再生成して適用）。

## 確認事項

- [ ] `terraform-prod-plan` が plan ログのみ出力して成功すること
- [ ] `terraform-prod-apply` が plan ファイルなしで適用成功すること