### PR TITLE
fix(terraform): SNOWFLAKE_USER/SNOWFLAKE_PRIVATE_KEY変数名を大文字に復元

### DIFF
--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -28,7 +28,7 @@ locals {
   snowflake_organization_name = var.snowflake_organization_name != null ? var.snowflake_organization_name : (length(local._account_parts) >= 2 ? local._account_parts[0] : null)
   snowflake_account_name      = var.snowflake_account_name != null ? var.snowflake_account_name : (length(local._account_parts) >= 2 ? join("-", slice(local._account_parts, 1, length(local._account_parts))) : null)
 
-  snowflake_private_key_effective = var.snowflake_private_key != null ? replace(var.snowflake_private_key, "\\n", "\n") : null
+  snowflake_private_key_effective = var.SNOWFLAKE_PRIVATE_KEY != null ? replace(var.SNOWFLAKE_PRIVATE_KEY, "\\n", "\n") : null
   snowflake_authenticator         = trimspace(replace(var.SNOWFLAKE_AUTHENTICATOR, "\r", ""))
   snowflake_role                  = var.SNOWFLAKE_ROLE != null ? trimspace(replace(var.SNOWFLAKE_ROLE, "\r", "")) : trimspace(replace(local.tf_admin_role, "\r", ""))
 
@@ -50,7 +50,7 @@ check "env_role_mismatch" {
 provider "snowflake" {
   organization_name = local.snowflake_organization_name
   account_name      = local.snowflake_account_name
-  user              = var.snowflake_user
+  user              = var.SNOWFLAKE_USER
   private_key       = local.snowflake_private_key_effective
   authenticator     = local.snowflake_authenticator
   role              = local.snowflake_role

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -343,14 +343,14 @@ variable "snowflake_account_name" {
   }
 }
 
-variable "snowflake_user" {
+variable "SNOWFLAKE_USER" {
   type        = string
   default     = null
   nullable    = true
   description = "Terraform実行に使用するSnowflakeユーザー名"
 }
 
-variable "snowflake_private_key" {
+variable "SNOWFLAKE_PRIVATE_KEY" {
   type        = string
   default     = null
   nullable    = true


### PR DESCRIPTION
## 原因

PR #184 内の `441beb5` で HCP 登録変数名（大文字）と不一致な `snowflake_user` / `snowflake_private_key`（小文字）に変更されたため、HCP 変数が `undeclared variable` 扱いで無視された。

その結果 `terraform-prod-apply` が null ユーザー・null 秘密鍵で実行され、`PROD_DBT_USER.rsa_public_key` が正しく更新されず JWT 認証エラーになっていた。

## 変更内容

- `terraform/variables.tf`: `snowflake_user` → `SNOWFLAKE_USER`、`snowflake_private_key` → `SNOWFLAKE_PRIVATE_KEY` に復元
- `terraform/providers.tf`: 上記変数を参照するよう修正

## 確認事項

- [ ] `terraform-prod-apply` が警告なし（Value for undeclared variable が出ない）で完了すること
- [ ] `dbt-debug-prod` が JWT エラーなしで接続成功すること