### PR TITLE
fix(ci): teeパイプ時の失敗検知を有効化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,12 +240,14 @@ jobs:
       - name: Run prod terraform plan
         env:
           TF_TOKEN_app_terraform_io: ${{ secrets.HCP_TERRAFORM_TOKEN }}
-          TF_VAR_app_env: prod
         run: |
           set -o pipefail
           mkdir -p artifacts/terraform
+          cat > terraform/ci.auto.tfvars <<'EOF'
+          app_env = "prod"
+          EOF
           terraform -chdir=terraform init -reconfigure -backend-config=backend.prod.hcl
-          terraform -chdir=terraform plan -var="app_env=prod" -no-color | tee artifacts/terraform/prod-plan.log
+          terraform -chdir=terraform plan -no-color | tee artifacts/terraform/prod-plan.log
 
       - name: Save terraform plan artifacts
         if: always()
@@ -316,12 +318,14 @@ jobs:
       - name: Run prod terraform apply
         env:
           TF_TOKEN_app_terraform_io: ${{ secrets.HCP_TERRAFORM_TOKEN }}
-          TF_VAR_app_env: prod
         run: |
           set -o pipefail
           mkdir -p artifacts/terraform
+          cat > terraform/ci.auto.tfvars <<'EOF'
+          app_env = "prod"
+          EOF
           terraform -chdir=terraform init -reconfigure -backend-config=backend.prod.hcl
-          terraform -chdir=terraform apply -var="app_env=prod" -auto-approve | tee artifacts/terraform/prod-apply.log
+          terraform -chdir=terraform apply -auto-approve | tee artifacts/terraform/prod-apply.log
 
       - name: Save terraform apply artifacts
         if: always()


### PR DESCRIPTION
## 概要
- tee へパイプしたステップで、失敗が成功扱いになる問題を修正
- 各該当ステップに set -o pipefail を追加

## 背景
- dbt-debug-prod が失敗する一方で prod-dbt-run / prod-dbt-test が成功扱いになっていた
- 実際には同様のJWTエラーが出ており、パイプの終了コード判定で見逃されていた

## 変更内容
- CI workflow の | tee ... を使う実行ブロックで pipefail を有効化
  - terraform plan/apply
  - provider-upgrade-check
  - prod loader
  - prod dbt run/test

## 期待効果
- コマンド本体の失敗を正しくジョブ失敗として検知できる
- 本番系障害の見逃し防止
