### PR TITLE
fix(ci): prod state migrationをCIで安全化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,14 +426,14 @@ jobs:
             state_body="$(terraform -chdir=terraform state show -no-color "$addr" 2>/dev/null || true)"
 
             if [ -n "$state_body" ]; then
-              if ! echo "$state_body" | grep -Eq 'network_policy\s*=\s*"PROD_TERRAFORM_NETWORK_POLICY"'; then
-                echo "::error::State entry exists but stale network_policy marker was not found: $addr"
-                exit 1
+              if echo "$state_body" | grep -Eq 'network_policy\s*=\s*"PROD_TERRAFORM_NETWORK_POLICY"'; then
+                echo "Verified stale network_policy attribute on: $addr"
+                terraform -chdir=terraform state rm "$addr"
+                removed_count=$((removed_count + 1))
+              else
+                echo "State already refreshed, keeping existing user entry: $addr"
+                return
               fi
-
-              echo "Verified stale network_policy attribute on: $addr"
-              terraform -chdir=terraform state rm "$addr"
-              removed_count=$((removed_count + 1))
             else
               echo "State already absent, importing fresh state for: $addr"
             fi


### PR DESCRIPTION
# 概要

prod 環境の Terraform state migration と apply ガードを CI 側で安全に扱えるように修正します。

# 変更内容

- HCP Terraform workspace の manual lock を apply 前に検知して即時 fail するように変更
- remote backend 利用時の `app_env` 注入を `ci.auto.tfvars` 方式へ統一
- `tee` 使用ステップで `set -o pipefail` を適用し、失敗を正しく検知
- 実現不能だった network policy 前提を Terraform・docs・bootstrap から撤去
- prod state の既知 migration リスクを `terraform-prod-state-preflight` で read-only 検知
- preflight を `terraform-prod-plan` より前に実行するよう順序を修正
- stale prod state を一回だけ掃除する `workflow_dispatch` cleanup job を `CI Pipeline` に統合
- cleanup job は prod environment 承認つきで実行し、before/after state artifact を保存
- cleanup job の再実行を許容し、user state は stale 時に remove+import、欠損時は import、fresh state はそのまま継続
- apply 前にも既存 Snowflake user の state が欠けていた場合の import 保険を追加
- `docs/DEPLOYMENT.md` の CI/CD 手順と cleanup 運用を更新

# 背景

prod では code 上は network policy 前提を撤去済みでしたが、remote state に stale な `snowflake_network_policy`、user の `network_policy` 属性、旧 functional role grant が残っており、plan/apply が refresh または revoke で失敗していました。

今回の変更で、通常の PR CI には破壊的操作を入れず、read-only の preflight で止めたうえで、必要な state migration のみを手動 dispatch + approval 付き job に隔離しています。

# 確認項目

- `python3 src/scripts/quality/check_code_quality.py --only yaml`
- `python3 src/scripts/quality/check_code_quality.py --only markdown`

# 注意事項

- `CI Pipeline` の `workflow_dispatch` から `run_prod_state_cleanup=true`、`confirm_prod_state_cleanup=true`、`run_prod_plan=false` を指定すると cleanup job のみ実行できます
- stale prod state の cleanup 後は、`terraform-prod-state-preflight` と `terraform-prod-plan` の再実行確認が必要です
- migration 完了後は cleanup 用 job を削除する想定です## 概要

Terraformによる Snowflake ガバナンス基盤を実装した。
Managed Access・RBAC 階層・削除保護・ネットワークポリシーの IaC 化に加え、
今回のレビューサイクルで発見された品質問題を一括対応している。

Closes #149

---

## 変更内容

### 基盤実装（#149 コア）
- `snowflake_schema` に `with_managed_access` を設定し、Terraform 実行ロール以外のアドホック GRANT を制限
- RBAC 階層（READ_ONLY / READ_WRITE / Loader / dbt / Streamlit / Bronze / Silver / Gold）を Terraform リソースとして実装
- `snowflake_grant_privileges_to_account_role` による最小権限付与、汎用モジュール `schema_object_grants` を作成
- 重要リソース（DB・Bronze テーブル）に `lifecycle { prevent_destroy = true }` を追加
- HCP Terraform ネットワークポリシーを実装

### コードレビュー対応（品質改善）

**セキュリティ・正確性**
- `SNOWFLAKE_ACCOUNT` の `split("-")` 固定インデックス `[1]` を `join("-", slice(..., 1, length))` に修正（ハイフン含むアカウント名に対応）
- `all_privileges` を使用箇所を明示権限リストに変更（最小権限原則）
- `SNOWFLAKE_AUTHENTICATOR` に許可リスト validation を追加

**依存関係の明示化（destroy 時のエラー防止）**
- Bronze テーブル・Silver/Gold スキーマ権限付与リソースの `local.*` 文字列参照を `snowflake_schema.*` / `snowflake_database.*` リソース参照に変更し、Terraform リソースグラフに明示的な依存関係を追加

**設定管理**
- `required_version` を `>= 1.6.0` → `>= 1.9.0` に引き上げ（クロス変数 validation の要件に対応）
- `schema_object_grants` サブモジュールに `versions.tf` を新規作成
- 子モジュールのプロバイダーバージョン固定 `= 2.13.0` を `>= 2.0.0` に緩和
- ネットワークポリシー IP リストのデフォルト値をモジュールから除去（`common.auto.tfvars` との二重管理を解消）
- `all_schemas_in_database` の冗長 USAGE 付与を削除（Bronze 層）

**環境変数の統一**
- `SNOWFLAKE_ACCOUNT` を `TF_VAR_SNOWFLAKE_ACCOUNT` に統一。Terraform への受け渡しと Python/dbt/Streamlit からの参照を 1 変数でカバー
- `.env` / `.env.example` / Python コード / `profiles.yml` / ドキュメント一式を更新

---

## テスト結果

- `terraform apply`（dev）: ✅ 正常完了
- `terraform destroy`（dev）: ✅ エラーなし完了（依存関係修正により解消）

---

## レビュー観点

- RBAC 権限設計（ロール階層・最小権限の妥当性）
- `prevent_destroy` 適用範囲の妥当性
- 環境変数名 `TF_VAR_SNOWFLAKE_ACCOUNT` の統一による影響範囲
