### PR TITLE
fix(ci): prod service user公開鍵をsecret基準で同期

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,14 +261,7 @@ jobs:
             key_file="$(mktemp)"
             public_key_file="$(mktemp)"
 
-            python3 - <<'PY' "$key_file" "$private_key_value"
-            import pathlib
-            import sys
-
-            path = pathlib.Path(sys.argv[1])
-            value = sys.argv[2].replace("\\n", "\n")
-            path.write_text(value, encoding="utf-8")
-            PY
+            python3 -c 'import pathlib, sys; pathlib.Path(sys.argv[1]).write_text(sys.argv[2].replace("\\n", "\n"), encoding="utf-8")' "$key_file" "$private_key_value"
 
             if [ -n "${SNOWFLAKE_PRIVATE_KEY_PASSPHRASE:-}" ]; then
               openssl pkey -pubout -in "$key_file" -passin env:SNOWFLAKE_PRIVATE_KEY_PASSPHRASE > "$public_key_file"
@@ -378,14 +371,7 @@ jobs:
             key_file="$(mktemp)"
             public_key_file="$(mktemp)"
 
-            python3 - <<'PY' "$key_file" "$private_key_value"
-            import pathlib
-            import sys
-
-            path = pathlib.Path(sys.argv[1])
-            value = sys.argv[2].replace("\\n", "\n")
-            path.write_text(value, encoding="utf-8")
-            PY
+            python3 -c 'import pathlib, sys; pathlib.Path(sys.argv[1]).write_text(sys.argv[2].replace("\\n", "\n"), encoding="utf-8")' "$key_file" "$private_key_value"
 
             if [ -n "${SNOWFLAKE_PRIVATE_KEY_PASSPHRASE:-}" ]; then
               openssl pkey -pubout -in "$key_file" -passin env:SNOWFLAKE_PRIVATE_KEY_PASSPHRASE > "$public_key_file"


### PR DESCRIPTION
# 概要

prod の dbt debug で発生していた JWT token is invalid を解消するため、Terraform plan/apply が service user の公開鍵を GitHub Secrets 上の秘密鍵から毎回導出するように修正します。

# 変更内容

- `terraform-prod-plan` で `PROD_LOADER_USER_RSA_PRIVATE_KEY` / `PROD_DBT_USER_RSA_PRIVATE_KEY` / `PROD_STREAMLIT_USER_RSA_PRIVATE_KEY` から公開鍵を導出
- 導出した公開鍵を `loader_user_rsa_public_key` / `dbt_user_rsa_public_key` / `streamlit_user_rsa_public_key` として `terraform/ci.auto.tfvars` に注入
- `terraform-prod-apply` にも同じ鍵導出処理を追加
- これにより HCP Terraform Workspace 側に古い公開鍵が残っていても、GitHub Actions で実際に使う秘密鍵と Terraform が管理する公開鍵を一致させる

# 背景

dbt debug は GitHub Secrets の `PROD_DBT_USER_RSA_PRIVATE_KEY` を使って JWT を生成する一方、Terraform は HCP Workspace の `dbt_user_rsa_public_key` を使って user の公開鍵を管理していました。

この 2 つがずれると、apply 自体は通っても dbt debug で `JWT token is invalid` が発生します。今回の修正で、prod の service user 3 種類すべてについて鍵ソースを GitHub Secrets 基準に揃えます。

# 確認項目

- `python3 src/scripts/quality/check_code_quality.py --only yaml`