### PR TITLE
refactor(ci): secret由来の公開鍵同期を削除

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,43 +240,12 @@ jobs:
       - name: Run prod terraform plan
         env:
           TF_TOKEN_app_terraform_io: ${{ secrets.HCP_TERRAFORM_TOKEN }}
-          PROD_LOADER_USER_RSA_PRIVATE_KEY: ${{ secrets.PROD_LOADER_USER_RSA_PRIVATE_KEY }}
-          PROD_DBT_USER_RSA_PRIVATE_KEY: ${{ secrets.PROD_DBT_USER_RSA_PRIVATE_KEY }}
-          PROD_STREAMLIT_USER_RSA_PRIVATE_KEY: ${{ secrets.PROD_STREAMLIT_USER_RSA_PRIVATE_KEY }}
-          SNOWFLAKE_PRIVATE_KEY_PASSPHRASE: ${{ secrets.SNOWFLAKE_PRIVATE_KEY_PASSPHRASE }}
         run: |
           set -o pipefail
           mkdir -p artifacts/terraform
           cat > terraform/ci.auto.tfvars <<'EOF'
           app_env = "prod"
           EOF
-
-          derive_public_key_tfvar() {
-            local private_key_value="$1"
-            local tfvar_name="$2"
-            local key_file public_key_file public_key_value
-
-            [ -n "$private_key_value" ] || return 0
-
-            key_file="$(mktemp)"
-            public_key_file="$(mktemp)"
-
-            python3 -c 'import pathlib, sys; pathlib.Path(sys.argv[1]).write_text(sys.argv[2].replace("\\n", "\n"), encoding="utf-8")' "$key_file" "$private_key_value"
-
-            if [ -n "${SNOWFLAKE_PRIVATE_KEY_PASSPHRASE:-}" ]; then
-              openssl pkey -pubout -in "$key_file" -passin env:SNOWFLAKE_PRIVATE_KEY_PASSPHRASE > "$public_key_file"
-            else
-              openssl pkey -pubout -in "$key_file" > "$public_key_file"
-            fi
-
-            public_key_value="$(sed '/BEGIN PUBLIC KEY/d;/END PUBLIC KEY/d' "$public_key_file" | tr -d '\n\r')"
-            printf '%s = "%s"\n' "$tfvar_name" "$public_key_value" >> terraform/ci.auto.tfvars
-            rm -f "$key_file" "$public_key_file"
-          }
-
-          derive_public_key_tfvar "$PROD_LOADER_USER_RSA_PRIVATE_KEY" loader_user_rsa_public_key
-          derive_public_key_tfvar "$PROD_DBT_USER_RSA_PRIVATE_KEY" dbt_user_rsa_public_key
-          derive_public_key_tfvar "$PROD_STREAMLIT_USER_RSA_PRIVATE_KEY" streamlit_user_rsa_public_key
 
           terraform -chdir=terraform init -reconfigure -backend-config=backend.prod.hcl
           terraform -chdir=terraform plan -lock-timeout=5m -no-color | tee artifacts/terraform/prod-plan.log
@@ -350,43 +319,12 @@ jobs:
       - name: Run prod terraform apply
         env:
           TF_TOKEN_app_terraform_io: ${{ secrets.HCP_TERRAFORM_TOKEN }}
-          PROD_LOADER_USER_RSA_PRIVATE_KEY: ${{ secrets.PROD_LOADER_USER_RSA_PRIVATE_KEY }}
-          PROD_DBT_USER_RSA_PRIVATE_KEY: ${{ secrets.PROD_DBT_USER_RSA_PRIVATE_KEY }}
-          PROD_STREAMLIT_USER_RSA_PRIVATE_KEY: ${{ secrets.PROD_STREAMLIT_USER_RSA_PRIVATE_KEY }}
-          SNOWFLAKE_PRIVATE_KEY_PASSPHRASE: ${{ secrets.SNOWFLAKE_PRIVATE_KEY_PASSPHRASE }}
         run: |
           set -o pipefail
           mkdir -p artifacts/terraform
           cat > terraform/ci.auto.tfvars <<'EOF'
           app_env = "prod"
           EOF
-
-          derive_public_key_tfvar() {
-            local private_key_value="$1"
-            local tfvar_name="$2"
-            local key_file public_key_file public_key_value
-
-            [ -n "$private_key_value" ] || return 0
-
-            key_file="$(mktemp)"
-            public_key_file="$(mktemp)"
-
-            python3 -c 'import pathlib, sys; pathlib.Path(sys.argv[1]).write_text(sys.argv[2].replace("\\n", "\n"), encoding="utf-8")' "$key_file" "$private_key_value"
-
-            if [ -n "${SNOWFLAKE_PRIVATE_KEY_PASSPHRASE:-}" ]; then
-              openssl pkey -pubout -in "$key_file" -passin env:SNOWFLAKE_PRIVATE_KEY_PASSPHRASE > "$public_key_file"
-            else
-              openssl pkey -pubout -in "$key_file" > "$public_key_file"
-            fi
-
-            public_key_value="$(sed '/BEGIN PUBLIC KEY/d;/END PUBLIC KEY/d' "$public_key_file" | tr -d '\n\r')"
-            printf '%s = "%s"\n' "$tfvar_name" "$public_key_value" >> terraform/ci.auto.tfvars
-            rm -f "$key_file" "$public_key_file"
-          }
-
-          derive_public_key_tfvar "$PROD_LOADER_USER_RSA_PRIVATE_KEY" loader_user_rsa_public_key
-          derive_public_key_tfvar "$PROD_DBT_USER_RSA_PRIVATE_KEY" dbt_user_rsa_public_key
-          derive_public_key_tfvar "$PROD_STREAMLIT_USER_RSA_PRIVATE_KEY" streamlit_user_rsa_public_key
 
           TF_ORGANIZATION="$(sed -n 's/^organization = "\(.*\)"/\1/p' terraform/backend.prod.hcl)"
           TF_WORKSPACE="$(sed -n 's/^  name = "\(.*\)"/\1/p' terraform/backend.prod.hcl)"


### PR DESCRIPTION
# 概要

prod の Terraform plan/apply で実施していた、GitHub Secrets の秘密鍵から公開鍵を導出して `ci.auto.tfvars` に注入する一時ロジックを削除します。

# 変更内容

- `terraform-prod-plan` から secret 由来の公開鍵導出処理を削除
- `terraform-prod-apply` から secret 由来の公開鍵導出処理を削除
- あわせて plan/apply にだけ追加していた秘密鍵系の一時 env 注入も削除

# 背景

GitHub Secrets を正本として毎回公開鍵を生成する方式は、運用上の責務分離が曖昧で、HCP Terraform Workspace Variables を正本とする現在の構成と競合しやすい状態でした。

今回の変更で、公開鍵の管理責務を Terraform 側の通常変数に戻し、一時的な CI 内同期ロジックを除去します。

# 確認項目

- `python3 src/scripts/quality/check_code_quality.py --only yaml`