### PR TITLE
feat: 配送範囲に応じた拠点サークル可視化を実装

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
+.vite/
 *.tsbuildinfo

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -476,7 +476,7 @@ function App() {
                                                 <p><span className="legend-dot is-low-cost" /> 低コスト注文</p>
                                                 <p><span className="legend-dot is-high-cost" /> 高コスト注文</p>
                                                 <p><span className="legend-dot is-unassigned" /> 未割当注文</p>
-                                                <p><span className="legend-dot is-center" /> 物流拠点</p>
+                                                <p><span className="legend-dot is-center" /> 拠点の配送範囲</p>
                                                 <div className="map-legend-metrics">
                                                     <span>表示注文数</span>
                                                     <strong>{formatInteger(dashboardData.map_order_rows.length)} 件</strong>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type CSSProperties } from "react";
+import { Component, useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import {
     fetchDashboardBootstrap,
     fetchHealth,
@@ -463,12 +463,14 @@ function App() {
                                             OpenStreetMap 上に注文データを最大 10,000 件表示します。未割当は赤、低コストは青、高コストは黄です。
                                         </p>
                                         <div className="map-layout is-embedded">
-                                            <SimulationMap
-                                                orderRows={dashboardData.map_order_rows}
-                                                centerRows={dashboardData.map_center_rows}
-                                                selectedOrderId={selectedOrderId}
-                                                selectedOrder={selectedMapOrder}
-                                            />
+                                            <MapErrorBoundary>
+                                                <SimulationMap
+                                                    orderRows={dashboardData.map_order_rows}
+                                                    centerRows={dashboardData.map_center_rows}
+                                                    selectedOrderId={selectedOrderId}
+                                                    selectedOrder={selectedMapOrder}
+                                                />
+                                            </MapErrorBoundary>
                                             <aside className="map-legend">
                                                 <h3>凡例</h3>
                                                 <p><span className="legend-dot is-low-cost" /> 低コスト注文</p>
@@ -904,3 +906,38 @@ function getOrderCenterOptions(rows: OrderRow[]): string[] {
 }
 
 export default App;
+
+type MapErrorBoundaryProps = {
+    children: ReactNode;
+};
+
+type MapErrorBoundaryState = {
+    hasError: boolean;
+};
+
+class MapErrorBoundary extends Component<MapErrorBoundaryProps, MapErrorBoundaryState> {
+    constructor(props: MapErrorBoundaryProps) {
+        super(props);
+        this.state = { hasError: false };
+    }
+
+    static getDerivedStateFromError(): MapErrorBoundaryState {
+        return { hasError: true };
+    }
+
+    componentDidCatch(error: Error): void {
+        console.error("SimulationMap render failed", error);
+    }
+
+    render(): ReactNode {
+        if (this.state.hasError) {
+            return (
+                <div className="map-panel">
+                    <div className="error-text">地図の描画に失敗しました。画面右下の凡例以外は引き続き利用できます。</div>
+                </div>
+            );
+        }
+
+        return this.props.children;
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -289,6 +289,9 @@ function App() {
     const orderCenterOptions = dashboardData ? getOrderCenterOptions(dashboardData.order_rows) : [];
     const selectedMapOrder = dashboardData?.map_order_rows.find((row) => row.order_id === selectedOrderId) ?? null;
     const scenarioGridStyle = getScenarioGridStyle(scenarioRows, scenarioDraftValues);
+    const sortedCenterSummaryRows = dashboardData
+        ? getSortedCenterSummaryRows(dashboardData.center_summary_rows, scenarioRows)
+        : [];
 
     return (
         <main className="app-shell">
@@ -433,15 +436,15 @@ function App() {
                                         <div className="chart-scroll-shell">
                                             <div
                                                 className="vertical-bar-chart"
-                                                style={{ width: `${Math.max(dashboardData.center_summary_rows.length * 44, 960)}px` }}
+                                                style={{ width: `${Math.max(sortedCenterSummaryRows.length * 44, 960)}px` }}
                                             >
-                                                {dashboardData.center_summary_rows.map((row) => (
+                                                {sortedCenterSummaryRows.map((row) => (
                                                     <div key={row.center_name} className="vertical-bar-item">
                                                         <div className="vertical-bar-value">{formatShortCurrency(row.total_cost)}</div>
                                                         <div className="vertical-bar-track">
                                                             <div
                                                                 className="vertical-bar-fill"
-                                                                style={{ height: `${getCostBarWidth(row.total_cost, dashboardData.center_summary_rows)}%` }}
+                                                                style={{ height: `${getCostBarWidth(row.total_cost, sortedCenterSummaryRows)}%` }}
                                                             />
                                                         </div>
                                                         <div className="vertical-bar-label">{row.center_name}</div>
@@ -504,7 +507,7 @@ function App() {
                                                     </tr>
                                                 </thead>
                                                 <tbody>
-                                                    {dashboardData.center_summary_rows.map((row) => (
+                                                    {sortedCenterSummaryRows.map((row) => (
                                                         <tr key={row.center_name}>
                                                             <td>{row.center_name}</td>
                                                             <td>{formatInteger(getScenarioRowByCenterName(scenarioRows, row.center_name)?.baseline_order_count ?? 0)}</td>
@@ -742,6 +745,32 @@ function getAssignmentSignature(rows: ScenarioRow[]): string {
 
 function getScenarioRowByCenterName(rows: ScenarioRow[], centerName: string): ScenarioRow | undefined {
     return rows.find((row) => row.center_name === centerName);
+}
+
+function getSortedCenterSummaryRows(
+    rows: DashboardResponse["center_summary_rows"],
+    scenarioRows: ScenarioRow[],
+): DashboardResponse["center_summary_rows"] {
+    const centerOrder = new Map(scenarioRows.map((row, index) => [row.center_name, index]));
+
+    return [...rows].sort((left, right) => {
+        const leftOrder = centerOrder.get(left.center_name);
+        const rightOrder = centerOrder.get(right.center_name);
+
+        if (leftOrder !== undefined && rightOrder !== undefined) {
+            return leftOrder - rightOrder;
+        }
+
+        if (leftOrder !== undefined) {
+            return -1;
+        }
+
+        if (rightOrder !== undefined) {
+            return 1;
+        }
+
+        return left.center_name.localeCompare(right.center_name, "ja");
+    });
 }
 
 function getScenarioFieldId(centerId: string, field: "staffing_level" | "fixed_cost"): string {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -231,10 +231,7 @@ function App() {
         }
 
         const timeoutId = window.setTimeout(() => {
-            void handleSimulate(scenarioRows, {
-                includeOrderRows: displayMode === "orders",
-                includeMapRows: displayMode === "dashboard",
-            });
+            void handleSimulate(scenarioRows);
         }, 250);
 
         return () => {
@@ -247,7 +244,7 @@ function App() {
             return;
         }
 
-        void handleSimulate(scenarioRows, { includeOrderRows: true, includeMapRows: false });
+        void handleSimulate(scenarioRows);
     }, [dashboardData, displayMode, isSimulating, scenarioRows]);
 
     useEffect(() => {
@@ -255,7 +252,7 @@ function App() {
             return;
         }
 
-        void handleSimulate(scenarioRows, { includeOrderRows: false, includeMapRows: true });
+        void handleSimulate(scenarioRows);
     }, [dashboardData, displayMode, isSimulating, scenarioRows]);
 
     useEffect(() => {
@@ -742,7 +739,7 @@ function isAbortError(error: unknown): boolean {
 }
 
 function getAssignmentSignature(rows: ScenarioRow[]): string {
-    return JSON.stringify(rows.map((row) => [row.center_id, row.staffing_level]));
+    return JSON.stringify(rows.map((row) => [row.center_id, row.staffing_level, row.fixed_cost]));
 }
 
 function getScenarioRowByCenterName(rows: ScenarioRow[], centerName: string): ScenarioRow | undefined {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -64,6 +64,8 @@ export type MapCenterRow = {
     center_lon: number;
     staffing_level: number;
     fixed_cost: number;
+    assigned_order_count: number;
+    delivery_radius_km: number;
 };
 
 export type DashboardResponse = {

--- a/frontend/src/components/SimulationMap.tsx
+++ b/frontend/src/components/SimulationMap.tsx
@@ -1,6 +1,6 @@
 import L from "leaflet";
-import { memo, useEffect, useMemo, useRef, useState } from "react";
-import { GeoJSON, MapContainer, TileLayer, useMap, useMapEvents } from "react-leaflet";
+import { memo, useEffect, useMemo, useState } from "react";
+import { Circle, GeoJSON, MapContainer, Marker, Popup, TileLayer, useMap, useMapEvents } from "react-leaflet";
 import type { MapCenterRow, MapOrderRow } from "../api/client.js";
 
 type SimulationMapProps = {
@@ -12,7 +12,6 @@ type SimulationMapProps = {
 
 export const SimulationMap = memo(function SimulationMap({ orderRows, centerRows, selectedOrderId, selectedOrder }: SimulationMapProps) {
     const [zoomLevel, setZoomLevel] = useState<number>(5);
-    const orderLayerRef = useRef<L.GeoJSON | null>(null);
     const orderFeatures = useMemo<GeoJSON.FeatureCollection<GeoJSON.Point>>(
         () => ({
             type: "FeatureCollection",
@@ -29,52 +28,6 @@ export const SimulationMap = memo(function SimulationMap({ orderRows, centerRows
         }),
         [orderRows],
     );
-
-    const centerFeatures = useMemo<GeoJSON.FeatureCollection<GeoJSON.Point>>(
-        () => ({
-            type: "FeatureCollection",
-            features: centerRows.map((row) => ({
-                type: "Feature",
-                geometry: {
-                    type: "Point",
-                    coordinates: [row.center_lon, row.center_lat],
-                },
-                properties: {
-                    ...row,
-                },
-            })),
-        }),
-        [centerRows],
-    );
-
-    useEffect(() => {
-        const orderLayer = orderLayerRef.current;
-        if (!orderLayer) {
-            return;
-        }
-
-        orderLayer.eachLayer((layer) => {
-            if (!(layer instanceof L.CircleMarker)) {
-                return;
-            }
-
-            const properties = layer.feature?.properties as MapOrderRow | undefined;
-            if (!properties) {
-                return;
-            }
-
-            const isSelected = properties.order_id === selectedOrderId;
-            layer.setRadius(getOrderRadius(properties.weight_kg, zoomLevel, isSelected));
-            layer.setStyle({
-                fillColor: getOrderColor(properties),
-                color: isSelected ? "#111827" : properties.is_unassigned ? "#7f1d1d" : "rgba(11, 26, 43, 0.12)",
-                weight: isSelected ? 2.4 : properties.is_unassigned ? 1.6 : 0.9,
-                opacity: 1,
-                fillOpacity: isSelected ? 1 : properties.is_unassigned ? 0.98 : 0.72,
-            });
-        });
-    }, [orderRows, selectedOrderId, zoomLevel]);
-
     return (
         <div className="map-panel">
             <MapContainer center={[36.2, 138.2]} zoom={5} scrollWheelZoom preferCanvas className="leaflet-map">
@@ -85,16 +38,14 @@ export const SimulationMap = memo(function SimulationMap({ orderRows, centerRows
                     url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
                 />
                 <GeoJSON
-                    ref={(layer) => {
-                        orderLayerRef.current = layer;
-                    }}
+                    key={`orders-${zoomLevel}-${selectedOrderId ?? "none"}`}
                     data={orderFeatures}
                     pointToLayer={(feature, latlng) => {
                         const properties = feature.properties as MapOrderRow;
                         const isSelected = properties.order_id === selectedOrderId;
 
                         return L.circleMarker(latlng, {
-                            radius: getOrderRadius(properties.weight_kg, zoomLevel, isSelected),
+                            radius: getOrderRadius(zoomLevel, isSelected),
                             fillColor: getOrderColor(properties),
                             color: isSelected ? "#111827" : properties.is_unassigned ? "#7f1d1d" : "rgba(11, 26, 43, 0.12)",
                             weight: isSelected ? 2.4 : properties.is_unassigned ? 1.6 : 0.9,
@@ -114,31 +65,58 @@ export const SimulationMap = memo(function SimulationMap({ orderRows, centerRows
                         );
                     }}
                 />
-                <GeoJSON
-                    data={centerFeatures}
-                    pointToLayer={(feature, latlng) => {
-                        const properties = feature.properties as MapCenterRow;
+                {centerRows.map((centerRow) => {
+                    const assignedOrderCount = getCenterAssignedOrderCount(centerRow);
+                    const deliveryRadiusKm = getCenterDeliveryRadiusKm(centerRow);
+                    const popupContent = (
+                        <>
+                            <strong>拠点:</strong> {centerRow.center_name}<br />
+                            <strong>担当件数:</strong> {assignedOrderCount.toLocaleString("ja-JP")} 件<br />
+                            <strong>配達半径:</strong> {deliveryRadiusKm.toFixed(1)} km<br />
+                            <strong>人員数:</strong> {centerRow.staffing_level.toLocaleString("ja-JP")} 人<br />
+                            <strong>固定費:</strong> ¥{Math.round(centerRow.fixed_cost).toLocaleString("ja-JP")}
+                        </>
+                    );
 
-                        return L.circleMarker(latlng, {
-                            radius: Math.max(9, Math.min(19, 9 + properties.staffing_level * 0.12)),
-                            fillColor: "rgba(18, 122, 142, 0.55)",
-                            color: "rgba(7, 59, 76, 0.95)",
-                            weight: 2,
-                            opacity: 1,
-                            fillOpacity: 0.78,
-                        });
-                    }}
-                    onEachFeature={(feature, layer) => {
-                        const properties = feature.properties as MapCenterRow;
-                        layer.bindPopup(
-                            [
-                                `<strong>拠点:</strong> ${properties.center_name}`,
-                                `<strong>人員数:</strong> ${properties.staffing_level.toLocaleString("ja-JP")} 人`,
-                                `<strong>固定費:</strong> ¥${Math.round(properties.fixed_cost).toLocaleString("ja-JP")}`,
-                            ].join("<br>"),
-                        );
-                    }}
-                />
+                    return (
+                        deliveryRadiusKm > 0 ? (
+                            <Circle
+                                key={`${centerRow.center_id}-range`}
+                                center={[centerRow.center_lat, centerRow.center_lon]}
+                                radius={deliveryRadiusKm * 1000}
+                                pathOptions={{
+                                    fillColor: "#ea580c",
+                                    color: "#c2410c",
+                                    weight: 2,
+                                    opacity: 0.78,
+                                    fillOpacity: 0.12,
+                                }}
+                            >
+                                <Popup>{popupContent}</Popup>
+                            </Circle>
+                        ) : null
+                    );
+                })}
+                {centerRows.map((centerRow) => {
+                    const assignedOrderCount = getCenterAssignedOrderCount(centerRow);
+                    const deliveryRadiusKm = getCenterDeliveryRadiusKm(centerRow);
+
+                    return (
+                        <Marker
+                            key={`${centerRow.center_id}-marker`}
+                            position={[centerRow.center_lat, centerRow.center_lon]}
+                            icon={getCenterMarkerIcon(centerRow.staffing_level)}
+                        >
+                            <Popup>
+                                <strong>拠点:</strong> {centerRow.center_name}<br />
+                                <strong>担当件数:</strong> {assignedOrderCount.toLocaleString("ja-JP")} 件<br />
+                                <strong>配達半径:</strong> {deliveryRadiusKm.toFixed(1)} km<br />
+                                <strong>人員数:</strong> {centerRow.staffing_level.toLocaleString("ja-JP")} 人<br />
+                                <strong>固定費:</strong> ¥{Math.round(centerRow.fixed_cost).toLocaleString("ja-JP")}
+                            </Popup>
+                        </Marker>
+                    );
+                })}
             </MapContainer>
         </div>
     );
@@ -171,9 +149,7 @@ function SelectedOrderViewport({ selectedOrder }: { selectedOrder?: MapOrderRow 
     return null;
 }
 
-function getOrderRadius(weightKg: number, zoomLevel: number, isSelected: boolean): number {
-    void weightKg;
-
+function getOrderRadius(zoomLevel: number, isSelected: boolean): number {
     if (zoomLevel <= 5) {
         return isSelected ? 4.5 : 3;
     }
@@ -191,4 +167,26 @@ function getAssignedCenterDisplayText(row: MapOrderRow): string {
     }
 
     return "未割当";
+}
+
+function getCenterAssignedOrderCount(row: MapCenterRow): number {
+    const value = (row as MapCenterRow & { assigned_order_count?: number }).assigned_order_count;
+    return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function getCenterDeliveryRadiusKm(row: MapCenterRow): number {
+    const value = (row as MapCenterRow & { delivery_radius_km?: number }).delivery_radius_km;
+    return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function getCenterMarkerIcon(staffingLevel: number): L.DivIcon {
+    const diameter = Math.max(14, Math.min(20, 14 + staffingLevel * 0.12));
+
+    return L.divIcon({
+        className: "center-marker-icon",
+        html: `<span style="display:block;width:${diameter}px;height:${diameter}px;border-radius:9999px;background:#9a3412;border:2px solid #7c2d12;box-shadow:0 0 0 2px rgba(255,255,255,0.9);"></span>`,
+        iconSize: [diameter, diameter],
+        iconAnchor: [diameter / 2, diameter / 2],
+        popupAnchor: [0, -diameter / 2],
+    });
 }

--- a/frontend/src/components/SimulationMap.tsx
+++ b/frontend/src/components/SimulationMap.tsx
@@ -1,6 +1,6 @@
 import L from "leaflet";
 import { memo, useEffect, useMemo, useState } from "react";
-import { Circle, GeoJSON, MapContainer, Marker, Popup, TileLayer, useMap, useMapEvents } from "react-leaflet";
+import { Circle, GeoJSON, MapContainer, Popup, TileLayer, useMap, useMapEvents } from "react-leaflet";
 import type { MapCenterRow, MapOrderRow } from "../api/client.js";
 
 type SimulationMapProps = {
@@ -97,26 +97,6 @@ export const SimulationMap = memo(function SimulationMap({ orderRows, centerRows
                         ) : null
                     );
                 })}
-                {centerRows.map((centerRow) => {
-                    const assignedOrderCount = getCenterAssignedOrderCount(centerRow);
-                    const deliveryRadiusKm = getCenterDeliveryRadiusKm(centerRow);
-
-                    return (
-                        <Marker
-                            key={`${centerRow.center_id}-marker`}
-                            position={[centerRow.center_lat, centerRow.center_lon]}
-                            icon={getCenterMarkerIcon(centerRow.staffing_level)}
-                        >
-                            <Popup>
-                                <strong>拠点:</strong> {centerRow.center_name}<br />
-                                <strong>担当件数:</strong> {assignedOrderCount.toLocaleString("ja-JP")} 件<br />
-                                <strong>配達半径:</strong> {deliveryRadiusKm.toFixed(1)} km<br />
-                                <strong>人員数:</strong> {centerRow.staffing_level.toLocaleString("ja-JP")} 人<br />
-                                <strong>固定費:</strong> ¥{Math.round(centerRow.fixed_cost).toLocaleString("ja-JP")}
-                            </Popup>
-                        </Marker>
-                    );
-                })}
             </MapContainer>
         </div>
     );
@@ -177,16 +157,4 @@ function getCenterAssignedOrderCount(row: MapCenterRow): number {
 function getCenterDeliveryRadiusKm(row: MapCenterRow): number {
     const value = (row as MapCenterRow & { delivery_radius_km?: number }).delivery_radius_km;
     return typeof value === "number" && Number.isFinite(value) ? value : 0;
-}
-
-function getCenterMarkerIcon(staffingLevel: number): L.DivIcon {
-    const diameter = Math.max(14, Math.min(20, 14 + staffingLevel * 0.12));
-
-    return L.divIcon({
-        className: "center-marker-icon",
-        html: `<span style="display:block;width:${diameter}px;height:${diameter}px;border-radius:9999px;background:#9a3412;border:2px solid #7c2d12;box-shadow:0 0 0 2px rgba(255,255,255,0.9);"></span>`,
-        iconSize: [diameter, diameter],
-        iconAnchor: [diameter / 2, diameter / 2],
-        popupAnchor: [0, -diameter / 2],
-    });
 }

--- a/frontend/src/components/SimulationMap.tsx
+++ b/frontend/src/components/SimulationMap.tsx
@@ -1,5 +1,5 @@
 import L from "leaflet";
-import { memo, useEffect, useMemo, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { GeoJSON, MapContainer, TileLayer, useMap, useMapEvents } from "react-leaflet";
 import type { MapCenterRow, MapOrderRow } from "../api/client.js";
 
@@ -12,6 +12,7 @@ type SimulationMapProps = {
 
 export const SimulationMap = memo(function SimulationMap({ orderRows, centerRows, selectedOrderId, selectedOrder }: SimulationMapProps) {
     const [zoomLevel, setZoomLevel] = useState<number>(5);
+    const orderLayerRef = useRef<L.GeoJSON | null>(null);
     const orderFeatures = useMemo<GeoJSON.FeatureCollection<GeoJSON.Point>>(
         () => ({
             type: "FeatureCollection",
@@ -46,6 +47,34 @@ export const SimulationMap = memo(function SimulationMap({ orderRows, centerRows
         [centerRows],
     );
 
+    useEffect(() => {
+        const orderLayer = orderLayerRef.current;
+        if (!orderLayer) {
+            return;
+        }
+
+        orderLayer.eachLayer((layer) => {
+            if (!(layer instanceof L.CircleMarker)) {
+                return;
+            }
+
+            const properties = layer.feature?.properties as MapOrderRow | undefined;
+            if (!properties) {
+                return;
+            }
+
+            const isSelected = properties.order_id === selectedOrderId;
+            layer.setRadius(getOrderRadius(properties.weight_kg, zoomLevel, isSelected));
+            layer.setStyle({
+                fillColor: getOrderColor(properties),
+                color: isSelected ? "#111827" : properties.is_unassigned ? "#7f1d1d" : "rgba(11, 26, 43, 0.12)",
+                weight: isSelected ? 2.4 : properties.is_unassigned ? 1.6 : 0.9,
+                opacity: 1,
+                fillOpacity: isSelected ? 1 : properties.is_unassigned ? 0.98 : 0.72,
+            });
+        });
+    }, [orderRows, selectedOrderId, zoomLevel]);
+
     return (
         <div className="map-panel">
             <MapContainer center={[36.2, 138.2]} zoom={5} scrollWheelZoom preferCanvas className="leaflet-map">
@@ -56,6 +85,9 @@ export const SimulationMap = memo(function SimulationMap({ orderRows, centerRows
                     url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
                 />
                 <GeoJSON
+                    ref={(layer) => {
+                        orderLayerRef.current = layer;
+                    }}
                     data={orderFeatures}
                     pointToLayer={(feature, latlng) => {
                         const properties = feature.properties as MapOrderRow;
@@ -75,8 +107,7 @@ export const SimulationMap = memo(function SimulationMap({ orderRows, centerRows
                         layer.bindPopup(
                             [
                                 `<strong>注文ID:</strong> ${properties.order_id}`,
-                                `<strong>担当拠点:</strong> ${properties.assigned_center_name}`,
-                                `<strong>割当状態:</strong> ${properties.assignment_status}`,
+                                `<strong>配達拠点:</strong> ${getAssignedCenterDisplayText(properties)}`,
                                 `<strong>重量:</strong> ${properties.weight_kg.toFixed(1)} kg`,
                                 `<strong>配送コスト:</strong> ¥${Math.round(properties.simulated_cost).toLocaleString("ja-JP")}`,
                             ].join("<br>"),
@@ -141,11 +172,23 @@ function SelectedOrderViewport({ selectedOrder }: { selectedOrder?: MapOrderRow 
 }
 
 function getOrderRadius(weightKg: number, zoomLevel: number, isSelected: boolean): number {
-    const weightRadius = Math.max(4.5, Math.min(10.5, 4.5 + weightKg / 18));
-    const zoomBonus = Math.max(0, zoomLevel - 5) * 0.35;
-    return Math.min(isSelected ? 17 : 13, weightRadius + zoomBonus + (isSelected ? 3.5 : 0));
+    void weightKg;
+
+    if (zoomLevel <= 5) {
+        return isSelected ? 4.5 : 3;
+    }
+
+    return isSelected ? 6.5 : 5.5;
 }
 
 function getOrderColor(row: MapOrderRow): string {
     return `rgb(${row.color_r}, ${row.color_g}, ${row.color_b})`;
+}
+
+function getAssignedCenterDisplayText(row: MapOrderRow): string {
+    if (row.assignment_status === "割当済" && row.assigned_center_name.trim() !== "") {
+        return row.assigned_center_name;
+    }
+
+    return "未割当";
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -642,7 +642,7 @@ tbody tr:last-child td {
 }
 
 .legend-dot.is-center {
-    background: rgba(18, 122, 142, 0.75);
+    background: rgba(234, 88, 12, 0.75);
 }
 
 .map-legend-metrics {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -642,7 +642,9 @@ tbody tr:last-child td {
 }
 
 .legend-dot.is-center {
-    background: rgba(234, 88, 12, 0.75);
+    background: rgba(234, 88, 12, 0.18);
+    border: 2px solid rgba(194, 65, 12, 0.78);
+    box-sizing: border-box;
 }
 
 .map-legend-metrics {

--- a/src/api/dashboard_service.py
+++ b/src/api/dashboard_service.py
@@ -236,9 +236,28 @@ def _build_dashboard_response(
     if len(map_order_df) > MAP_SAMPLE_SIZE:
         map_order_df = map_order_df.sample(n=MAP_SAMPLE_SIZE, random_state=0).copy()
     map_order_df = _calculate_map_colors(map_order_df)
+    assigned_center_metrics_df = order_plot_df.loc[
+        (~order_plot_df["IS_UNASSIGNED"].astype(bool)) & order_plot_df["ASSIGNED_CENTER_ID"].notna()
+    ].assign(ASSIGNED_CENTER_ID=lambda df: df["ASSIGNED_CENTER_ID"].astype(str))
+    assigned_center_metrics_df = assigned_center_metrics_df.loc[assigned_center_metrics_df["ASSIGNED_CENTER_ID"] != ""]
+    assigned_center_metrics_df = assigned_center_metrics_df.groupby("ASSIGNED_CENTER_ID", as_index=False).agg(
+        assigned_order_count=("ORDER_ID", "nunique"),
+        delivery_radius_km=("SIMULATED_DISTANCE_KM", "max"),
+    )
+
     map_center_df = sanitized_scenario_df[
         ["center_id", "center_name", "center_lat", "center_lon", "staffing_level", "fixed_cost"]
     ].copy()
+    map_center_df = map_center_df.merge(
+        assigned_center_metrics_df,
+        left_on="center_id",
+        right_on="ASSIGNED_CENTER_ID",
+        how="left",
+    ).drop(columns=["ASSIGNED_CENTER_ID"], errors="ignore")
+    map_center_df["assigned_order_count"] = (
+        pd.to_numeric(map_center_df["assigned_order_count"], errors="coerce").fillna(0).astype(int)
+    )
+    map_center_df["delivery_radius_km"] = pd.to_numeric(map_center_df["delivery_radius_km"], errors="coerce").fillna(0.0)
 
     total_cost = simulation_result.total_cost
     total_orders = len(simulation_result.assignments)
@@ -316,6 +335,8 @@ def _build_dashboard_response(
                     center_lon=float(row["center_lon"]),
                     staffing_level=int(row["staffing_level"]),
                     fixed_cost=float(row["fixed_cost"]),
+                    assigned_order_count=int(row["assigned_order_count"]),
+                    delivery_radius_km=float(row["delivery_radius_km"]),
                 )
                 for row in map_center_df.to_dict(orient="records")
             ]

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -63,6 +63,8 @@ class MapCenterRow(BaseModel):
     center_lon: float
     staffing_level: int
     fixed_cost: float
+    assigned_order_count: int
+    delivery_radius_km: float
 
 
 class DashboardResponse(BaseModel):


### PR DESCRIPTION
## 概要
- 拠点ごとの最遠配達距離に基づく配送範囲の可視化を追加
- 地図上の配達先表示と分析詳細の並び順を調整
- 拠点情報変更時に地図と注文別データ一覧も含めて全体同期するよう統一

## 変更内容
- API の `map_center_rows` に `assigned_order_count` と `delivery_radius_km` を追加
- 地図上に拠点ごとの半透明な配送範囲円を表示
- 配達先ポップアップの表示文言を整理し、拠点マーカーは削除
- 分析詳細の表示順を拠点順に補正
- 拠点情報の変更時に、ダッシュボード表示中でも注文一覧と地図を含めて再計算するよう変更
- frontend の `.vite/` を ignore 対象に追加

## 確認内容
- `cd frontend && npm run build`
- 地図が落ちずに表示されること
- 配送範囲円が表示されること
- 拠点情報変更時に地図と注文別データ一覧が同期更新されること

## 関連
- Closes #208
