### PR TITLE
perf: Goldマートにcluster_byを追加

### DIFF
--- a/src/transform/README.md
+++ b/src/transform/README.md
@@ -131,11 +131,24 @@ uv run python src/scripts/deploy/run_dbt.py test
 対象ファイル。
 
 - `models/marts/fct_delivery_analysis.sql`
+- `models/marts/fct_delivery_candidate_rankings.sql`
 
 主な役割。
 
 - `int_delivery_cost_candidates` から注文ごとの最安候補を 1 件選択
-- Gold 層の分析用ビューとして公開
+- Streamlit / API から直接参照する Gold 層の公開テーブルとして保持
+
+materialization / clustering 方針。
+
+- `fct_delivery_analysis` は `materialized='table'` を採用
+- `cluster_by=['prefecture', 'center_name']` を指定し、都道府県別・拠点別の分析参照を優先
+- `fct_delivery_candidate_rankings` も `materialized='table'` を採用
+- `cluster_by=['order_candidate_rank', 'center_id']` を指定し、`order_candidate_rank = 1` の抽出と拠点軸の候補参照を優先
+
+補足。
+
+- `staging` / `intermediate` の既定値は `view` のまま維持
+- Gold の主要マートだけを table 化し、Streamlit / BI の参照性能と Snowflake の再計算コストを両立する
 
 ## 6. よくあるエラーと対処
 

--- a/src/transform/models/marts/fct_delivery_analysis.sql
+++ b/src/transform/models/marts/fct_delivery_analysis.sql
@@ -1,4 +1,7 @@
-{{ config(materialized='table') }}
+{{ config(
+    materialized='table',
+    cluster_by=['prefecture', 'center_name']
+) }}
 
 with ranked_candidates as (
     select * from {{ ref('fct_delivery_candidate_rankings') }}

--- a/src/transform/models/marts/fct_delivery_candidate_rankings.sql
+++ b/src/transform/models/marts/fct_delivery_candidate_rankings.sql
@@ -1,4 +1,7 @@
-{{ config(materialized='table') }}
+{{ config(
+    materialized='table',
+    cluster_by=['order_candidate_rank', 'center_id']
+) }}
 
 with candidate_costs as (
     select * from {{ ref('int_delivery_cost_candidates') }}


### PR DESCRIPTION
## 概要
- Gold マートに `cluster_by` を追加
- cluster_by の選定理由を dbt README に追記

## 変更内容
- `fct_delivery_analysis` に `cluster_by=['prefecture', 'center_name']` を追加
- `fct_delivery_candidate_rankings` に `cluster_by=['order_candidate_rank', 'center_id']` を追加
- `src/transform/README.md` に Gold マートの materialization / clustering 方針を追記

## 変更理由
- Streamlit / API から直接参照する Gold テーブルの物理設計方針をコード上で明示するため
- 現時点で劇的な速度改善は見込みにくいが、参照パターンに対応した clustering 方針を先に整理しておくため

## 確認内容
- `cd src/transform && dbt parse`

## 関連
- Closes #230
